### PR TITLE
tick and wind basic test-suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 temp
 build
+.DS_Store

--- a/contracts/jetton.tact
+++ b/contracts/jetton.tact
@@ -1,0 +1,54 @@
+import "@stdlib/deploy";
+import "./packages/token/jetton/JettonMaster";
+import "./packages/token/jetton/JettonWallet";
+
+contract ExampleJettonWallet with JettonWallet {
+    balance: Int as coins = 0;
+    owner: Address;
+    jetton_master: Address;
+
+    init(owner: Address, jetton_master: Address) {
+        self.owner = owner;
+        self.jetton_master = jetton_master;
+    }
+
+    override inline fun calculate_jetton_wallet_init(owner_address: Address): StateInit {
+        return initOf ExampleJettonWallet(owner_address, self.jetton_master);
+    }
+}
+
+contract ExampleJettonMaster with JettonMaster, Deployable {
+    total_supply: Int as coins = 0;
+    mintable: Bool = true;
+    owner: Address;
+    jetton_content: Cell;
+
+    init(owner: Address, jetton_content: Cell){
+        self.owner = owner;
+        self.jetton_content = jetton_content;
+    }
+
+    receive("Mint:1") {
+        let ctx: Context = context();
+        let msg: JettonMint = JettonMint{
+            origin: ctx.sender,
+            receiver: ctx.sender,
+            amount: ton("100"),
+            custom_payload: emptyCell(),
+            forward_ton_amount: 0,
+            forward_payload: emptySlice()
+        };
+        self._mint_validate(ctx, msg);
+        self._mint(ctx, msg);
+    }
+
+    override inline fun _mint_validate(ctx: Context, msg: JettonMint) {
+        require(self.mintable, "JettonMaster: Jetton is not mintable");
+    }
+
+    override inline fun calculate_jetton_wallet_init(owner_address: Address): StateInit {
+        return initOf ExampleJettonWallet(owner_address, myAddress());
+    }
+
+
+}

--- a/contracts/oracle.tact
+++ b/contracts/oracle.tact
@@ -141,6 +141,7 @@ contract Alarm with Initializable, FixedPoint156x100 {
         self.quoteAssetScale = msg.scale; // 1
         self.remainScale = msg.scale; // 1
         self.baseAssetPrice = msg.baseAssetPrice; // 3
+
         // Return the remaining funds back to the Watchmaker
         send(SendParameters{
                 to: self.watchmaker,
@@ -161,7 +162,7 @@ contract Alarm with Initializable, FixedPoint156x100 {
         // 3. Send Chime message to the Oracle to create a new alarm
         let ctx: Context = context();
         self.requireOracle(ctx.sender);
-        require(self.remainScale >= msg.buyNum, "Not enough scale to buy"); // MODIFIED: >=
+        require(self.remainScale >= msg.buyNum, "Not enough scale to buy"); // MODIFIED: >= , and if this requirement is not satisfied, the jetton doesn't return back to the timekeeper
         let failed: Bool = false;
         let refundBaseAssetAmount: Int = 0; // 0 means return as much as possible
         let refundQuoteAssetAmount: Int = 0;
@@ -197,14 +198,14 @@ contract Alarm with Initializable, FixedPoint156x100 {
                 value: ctx.value - ton("0.02"), // MODEFIED: - ton("0.02")
                 mode: SendIgnoreErrors,
                 body: Chime{
-                    alarmIndex: self.index,
-                    timeKeeper: msg.sender, // here is a problem
-                    baseAssetPrice: baseAssetPrice,
+                    alarmIndex: self.index, // 0
+                    timeKeeper: msg.sender, 
+                    baseAssetPrice: baseAssetPrice, // 3
                     createdAt: self.createdAt,
-                    remainScale: self.remainScale,
-                    newScale: msg.buyNum << 1,
-                    refundQuoteAssetAmount: refundQuoteAssetAmount,
-                    refundBaseAssetAmount: refundBaseAssetAmount
+                    remainScale: self.remainScale, // 0
+                    newScale: msg.buyNum << 1, // 2
+                    refundQuoteAssetAmount: refundQuoteAssetAmount, // 0
+                    refundBaseAssetAmount: refundBaseAssetAmount // 0
                 }.toCell()
             }
         );
@@ -363,13 +364,14 @@ contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
             let alarmIndex: Int = sc.loadUint(256);
             let buyNum: Int = sc.loadUint(32);
             let side: Int = sc.loadUint(1);
+            // Don't we need to add new baseprice? right now the alarm that timekeep build its baseprice is 0
             require(alarmIndex < self.totalAlarms, "alarmIndex out of range");
             require(side == 0 || side == 1, "side must be either 0 or 1");
             send(SendParameters{
                     to: contractAddress(self._calculateAlarmInit(alarmIndex)),
                     value: (ctx.value - STORAGE_FEE),
                     mode: 0,
-                    body: Reset{sender: msg.sender, buyNum: buyNum, side: side, quoteAssetAmount: msg.amount}.toCell()
+                    body: Reset{sender: msg.sender, buyNum: buyNum, side: side, quoteAssetAmount: msg.amount}.toCell() // MODIFIED: sender is msg.sender, not ctx.sender
                 }
             );
             return ;
@@ -394,6 +396,7 @@ contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
         // Receive Chime message from Alarm contract
         self.requireInitialized();
         self.requireAlarm(msg.alarmIndex);
+        // We don't have to check this is after the verified time?
         if (msg.remainScale > 0) {
             self.sync(msg.createdAt, msg.baseAssetPrice);
         }
@@ -413,10 +416,10 @@ contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
                 data: initCode.data
             }
         );
+        self.totalAlarms = (self.totalAlarms + 1); // MODIFIED: Miss to add totalAlarms
         // Transfer the remaining funds or profits to the TimeKeeper
         let ctx: Context = context();
         if (msg.refundQuoteAssetAmount > 0) {
-            dump("1");
             // Send Jetton Transfer message to refund
             send(SendParameters{
                     to: self.quoteAssetWallet,
@@ -436,7 +439,6 @@ contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
             return ;
         }
         if (msg.refundBaseAssetAmount > 0) {
-            dump("2");
             send(SendParameters{
                     to: msg.timeKeeper,
                     value: msg.refundBaseAssetAmount,
@@ -446,7 +448,6 @@ contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
             );
             return ;
         }
-        dump("3");
     }
 
     receive(msg: Check){
@@ -538,5 +539,9 @@ contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
 
     get fun TotalAmount(): Int {
         return self.totalAlarms;
+    }
+
+    get fun getLatestBaseAssetPrice(): Int {
+        return self.latestBaseAssetPrice;
     }
 }

--- a/contracts/oracle.tact
+++ b/contracts/oracle.tact
@@ -118,7 +118,7 @@ contract Alarm with Initializable, FixedPoint156x100 {
     }
 
     override inline fun requireNotInitialized() {
-        // !!! Change from oracle address to watchmaker address
+        // MODIFIED: Change from oracle address to watchmaker address
         require(self.watchmaker == newAddress(0, 0), "Already initialized");
     }
 
@@ -318,6 +318,7 @@ contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
             let scale: Int = sc.loadUint(32);
             if (expireAt > currentTimestamp || scale != 1) {
                 // Return jetton back if gas is enough
+                // TODO: we can't send this msg to wallet and return jetton back, we have to send jetton transfer msg to send jetton back
                 send(SendParameters{
                         to: ctx.sender,
                         value: ((ctx.value - ctx.readForwardFee()) - STORAGE_FEE),
@@ -328,18 +329,21 @@ contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
                 return ;
             }
             // Preserve the baseAssetAmount
-            let needBaseAssetAmount: Int = 1000000000 * msg.amount.float() / baseAssetPrice; // !!! x 1000000000 to become ton unit
+            let needBaseAssetAmount: Int = 1000000000 * msg.amount.float() / baseAssetPrice; // MODIFIED: x 1000000000 to become ton unit
             require(needBaseAssetAmount > MIN_BASEASSET_TRESHOLD, "baseAssetAmount is too small");
             require(ctx.value > (needBaseAssetAmount + 2 * (ctx.readForwardFee() + STORAGE_FEE)),
                 "Insufficient funds to pay for the gas"
             );
+            // TODO: If the requirement above is not satisfied, return the funds and jetton back to the Watchmaker
             nativeReserve(needBaseAssetAmount, 0);
+            // MODIFIED: origin is value:0 mode: SendPayGasSeparately
+            let sendBackAmount: Int = (ctx.value - needBaseAssetAmount - 2 * (ctx.readForwardFee() + STORAGE_FEE));
             // Open a new alarm
             let initCode: StateInit = self._calculateAlarmInit(self.totalAlarms);
             send(SendParameters{
                     to: contractAddress(initCode),
-                    value: ton("0.05"),
-                    mode: SendPayGasSeparately,
+                    value: sendBackAmount,
+                    mode: SendIgnoreErrors,
                     body: Tock{
                         scale: scale,
                         createdAt: currentTimestamp,

--- a/contracts/oracle.tact
+++ b/contracts/oracle.tact
@@ -137,10 +137,10 @@ contract Alarm with Initializable, FixedPoint156x100 {
         self.createdAt = now();
         self.oracleAddress = sender;
         self.watchmaker = msg.watchmaker;
-        self.baseAssetScale = msg.scale;
-        self.quoteAssetScale = msg.scale;
-        self.remainScale = msg.scale;
-        self.baseAssetPrice = msg.baseAssetPrice;
+        self.baseAssetScale = msg.scale; // 1
+        self.quoteAssetScale = msg.scale; // 1
+        self.remainScale = msg.scale; // 1
+        self.baseAssetPrice = msg.baseAssetPrice; // 3
         // Return the remaining funds back to the Watchmaker
         send(SendParameters{
                 to: self.watchmaker,
@@ -161,7 +161,7 @@ contract Alarm with Initializable, FixedPoint156x100 {
         // 3. Send Chime message to the Oracle to create a new alarm
         let ctx: Context = context();
         self.requireOracle(ctx.sender);
-        require(self.remainScale > msg.buyNum, "Not enough scale to buy");
+        require(self.remainScale >= msg.buyNum, "Not enough scale to buy"); // MODIFIED: >=
         let failed: Bool = false;
         let refundBaseAssetAmount: Int = 0; // 0 means return as much as possible
         let refundQuoteAssetAmount: Int = 0;
@@ -193,12 +193,12 @@ contract Alarm with Initializable, FixedPoint156x100 {
             baseAssetPrice = self.baseAssetPrice;
         }
         send(SendParameters{
-                to: msg.sender,
-                value: (ctx.value - STORAGE_FEE),
+                to: ctx.sender,
+                value: ctx.value - ton("0.02"), // MODEFIED: - ton("0.02")
                 mode: SendIgnoreErrors,
                 body: Chime{
                     alarmIndex: self.index,
-                    timeKeeper: msg.sender,
+                    timeKeeper: msg.sender, // here is a problem
                     baseAssetPrice: baseAssetPrice,
                     createdAt: self.createdAt,
                     remainScale: self.remainScale,
@@ -369,7 +369,7 @@ contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
                     to: contractAddress(self._calculateAlarmInit(alarmIndex)),
                     value: (ctx.value - STORAGE_FEE),
                     mode: 0,
-                    body: Reset{sender: ctx.sender, buyNum: buyNum, side: side, quoteAssetAmount: msg.amount}.toCell()
+                    body: Reset{sender: msg.sender, buyNum: buyNum, side: side, quoteAssetAmount: msg.amount}.toCell()
                 }
             );
             return ;
@@ -401,7 +401,7 @@ contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
         let initCode: StateInit = self._calculateAlarmInit(self.totalAlarms);
         send(SendParameters{
                 to: contractAddress(initCode),
-                value: 0,
+                value: ton("0.05"), // MODIFIED: it has to be at least 0.05 ton to initialize a new alarm
                 mode: 0,
                 body: Tock{
                     createdAt: now(),
@@ -416,6 +416,7 @@ contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
         // Transfer the remaining funds or profits to the TimeKeeper
         let ctx: Context = context();
         if (msg.refundQuoteAssetAmount > 0) {
+            dump("1");
             // Send Jetton Transfer message to refund
             send(SendParameters{
                     to: self.quoteAssetWallet,
@@ -435,6 +436,7 @@ contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
             return ;
         }
         if (msg.refundBaseAssetAmount > 0) {
+            dump("2");
             send(SendParameters{
                     to: msg.timeKeeper,
                     value: msg.refundBaseAssetAmount,
@@ -444,6 +446,7 @@ contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
             );
             return ;
         }
+        dump("3");
     }
 
     receive(msg: Check){

--- a/contracts/oracle.tact
+++ b/contracts/oracle.tact
@@ -16,7 +16,7 @@ message Initialize {
     quoteAssetWallet: Address; // e.g. jetton wallet address for USDT
 }
 message Tick {
-    validBefore: Int as uint256; // If now() is larger than validBefore, then return the funds back to the Watchmaker if value is enough to pay the gas
+    expireAt: Int as uint256; // If now() is larger than expireAt, then return the funds back to the Watchmaker if value is enough to pay the gas
     baseAssetPrice: Int as uint256; // baseAsset price relative to quoteAsset
     scale: Int as uint32; // Scale is a multiplier of the MIN_BASEASSET_TRESHOLD, valid range is [1, 100]
 }
@@ -118,7 +118,8 @@ contract Alarm with Initializable, FixedPoint156x100 {
     }
 
     override inline fun requireNotInitialized() {
-        require(self.oracleAddress == newAddress(0, 0), "Already initialized");
+        // !!! Change from oracle address to watchmaker address
+        require(self.watchmaker == newAddress(0, 0), "Already initialized");
     }
 
     inline fun requireOracle(sender: Address) {
@@ -128,10 +129,9 @@ contract Alarm with Initializable, FixedPoint156x100 {
     receive(msg: Tock){
         // Receive a Tock message from the Oracle, should initialize the parameters
         // This function should be called only once with contract creation
-
         let sender: Address = sender();
         // Check the request is valid
-        self.requireNotInitialized();
+        self.requireNotInitialized(); 
         self.requireOracle(sender);
         // Initialize the parameters
         self.createdAt = now();
@@ -231,6 +231,27 @@ contract Alarm with Initializable, FixedPoint156x100 {
             }
         );
     }
+
+    // Get Methods
+    get fun getWatchmaker(): Address {
+        return self.watchmaker;
+    }
+
+    get fun getBaseAssetScale(): Int {
+        return self.baseAssetScale;
+    }
+
+    get fun getQuoteAssetScale(): Int {
+        return self.quoteAssetScale;
+    }
+
+    get fun getRemainScale(): Int {
+        return self.remainScale;
+    }
+
+    get fun getBaseAssetPrice(): Int {
+        return self.baseAssetPrice;
+    }
 }
 
 contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
@@ -269,8 +290,9 @@ contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
 
     receive(msg: Initialize){
         require(self.is_initialized == false, "Already initialized");
-        require(sender() == self.manager, "Only manager can initialize");
+        require(sender() == self.manager, "Only manager can initialize"); //Can not pass, cause manager is not set yet
         require(msg.baseAssetWallet == newAddress(0, 0), "Only support TON as baseAsset");
+        self.manager = sender();
         self.is_initialized = true;
         self.baseAssetWallet = msg.baseAssetWallet;
         self.quoteAssetWallet = msg.quoteAssetWallet;
@@ -284,15 +306,17 @@ contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
             return ;
         }
         require(ctx.sender == self.quoteAssetWallet, "Only oracle quoteAsset wallet can send notification to oracle");
-        let sc: Slice = msg.forward_payload;
+        let payload: Slice = msg.forward_payload;
+        let ref: Cell = payload.loadRef();
+        let sc: Slice = ref.beginParse();
         let opCode: Int = sc.loadUint(8); // 0 means Tick, 1 means Wind
         if (opCode == 0) {
             // Method: Tick
             let currentTimestamp: Int = now();
-            let validBefore: Int = sc.loadUint(256);
+            let expireAt: Int = sc.loadUint(256);
             let baseAssetPrice: Int = sc.loadUint(256); // The first 156 bits is integer part, the last 100 bits is float part
             let scale: Int = sc.loadUint(32);
-            if (validBefore > currentTimestamp || scale != 1) {
+            if (expireAt > currentTimestamp || scale != 1) {
                 // Return jetton back if gas is enough
                 send(SendParameters{
                         to: ctx.sender,
@@ -304,7 +328,7 @@ contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
                 return ;
             }
             // Preserve the baseAssetAmount
-            let needBaseAssetAmount: Int = msg.amount * baseAssetPrice;
+            let needBaseAssetAmount: Int = 1000000000 * msg.amount.float() / baseAssetPrice; // !!! x 1000000000 to become ton unit
             require(needBaseAssetAmount > MIN_BASEASSET_TRESHOLD, "baseAssetAmount is too small");
             require(ctx.value > (needBaseAssetAmount + 2 * (ctx.readForwardFee() + STORAGE_FEE)),
                 "Insufficient funds to pay for the gas"
@@ -314,7 +338,7 @@ contract OracleV0 with Deployable, Initializable, FixedPoint156x100 {
             let initCode: StateInit = self._calculateAlarmInit(self.totalAlarms);
             send(SendParameters{
                     to: contractAddress(initCode),
-                    value: 0,
+                    value: ton("0.05"),
                     mode: SendPayGasSeparately,
                     body: Tock{
                         scale: scale,

--- a/contracts/packages/token/jetton/JettonMaster.tact
+++ b/contracts/packages/token/jetton/JettonMaster.tact
@@ -1,0 +1,127 @@
+/*
+    This file provides traits for TEP-0074, TEP-0064 jetton standard
+
+    [TEP0074](https://github.com/ton-blockchain/TEPs/blob/master/text/0074-jettons-standard.md)
+    [Official FunC implementation](https://github.com/ton-blockchain/token-contract/blob/main/ft/jetton-wallet.fc)
+    [Ton Minter Contract](https://github.com/ton-blockchain/minter-contract)
+    [Tact Template](https://github.com/howardpen9/jetton-implementation-in-tact/blob/main/sources/contract.tact)
+*/
+import "./JettonWallet";
+
+struct JettonData {
+    total_supply: Int as coins; // the total number of issues jettons
+    mintable: Bool;             // flag which indicates whether number of jettons can increase admin_address
+    admin_address: Address;     // address of smart-contrac which control Jetton
+    jetton_content: Cell;       // data in accordance to Token Data Standard #64
+    jetton_wallet_code: Cell;   // code of wallet for that jetton
+}
+
+message JettonMint {
+    origin: Address;        // address of origin mint request (may be wallet v4)
+    receiver: Address;      // address of receiver
+    amount: Int;            // amount of jettons to mint
+    custom_payload: Cell?;  // optional custom data
+    forward_ton_amount: Int as coins;
+    forward_payload: Slice as remaining;
+}
+
+trait JettonMaster {
+    total_supply: Int;      // the total number of issued jettons
+    mintable: Bool;         // flag which indicates whether minting is allowed
+    owner: Address;         // owner of this jetton
+    jetton_content: Cell;   // data in accordance to Token Data Standard #64
+
+    //********************************************//
+    //                  Messages                  //
+    //********************************************//
+
+    // @dev  JettonBurnNotification is sent from Jetton wallet after burning jettons
+    receive(msg: JettonBurnNotification) {
+        let ctx: Context = context();
+        self._burn_notification_validate(ctx, msg);
+        self._burn_notification(ctx, msg);
+    }
+
+    // @dev  JettonMint is sent from user to mint jettons
+    receive(msg: JettonMint) {
+        let ctx: Context = context();
+        self._mint_validate(ctx, msg);
+        self._mint(ctx, msg);
+    }
+
+    //********************************************//
+    //             Internal functions             //
+    //********************************************//
+
+    // @dev  calculate_jetton_wallet_init retrieve init code of a jetton wallet
+    // @note one MUST override this function in inherited contract
+    abstract inline fun calculate_jetton_wallet_init(owner_address: Address): StateInit;
+
+    // @dev  _mint_validate conduct some custom validating before mint
+    virtual inline fun _mint_validate(ctx: Context, msg: JettonMint) {
+        require(ctx.sender == self.owner, "JettonMaster: Sender is not a Jetton owner");
+        require(self.mintable, "JettonMaster: Jetton is not mintable");
+    }
+
+    // @dev  _mint mint jettons
+    virtual inline fun _mint(ctx: Context, msg: JettonMint) {
+        let initCode: StateInit = self.calculate_jetton_wallet_init(msg.receiver);
+        self.total_supply = self.total_supply + msg.amount;
+        send(SendParameters{
+            to: contractAddress(initCode),
+            value: 0,
+            bounce: true,
+            mode: SendRemainingValue,
+            body: JettonInternalTransfer{ 
+                query_id: 0,
+                amount: msg.amount,
+                response_address: msg.origin,
+                from: myAddress(),
+                forward_ton_amount: msg.forward_ton_amount,
+                forward_payload: msg.forward_payload
+            }.toCell(),
+            code: initCode.code,
+            data: initCode.data
+        });
+    }
+
+    // @dev  _burn_notification_validate perform some custom validation after receiving JettonBurnNotification sent from Jetton wallet
+    virtual inline fun _burn_notification_validate(ctx: Context, msg: JettonBurnNotification) {
+        let initCode: StateInit = self.calculate_jetton_wallet_init(msg.sender);
+        require(ctx.sender == contractAddress(initCode), "Sender is not a Jetton wallet");
+    } 
+
+    // @dev  _burn_notification dwindles total_supply and send notification to wallet after receiving JettonBurnNotification
+    inline fun _burn_notification(ctx: Context, msg: JettonBurnNotification) {
+        self.total_supply = self.total_supply - msg.amount;
+        if(msg.response_destination != newAddress(0, 0)){
+            send(SendParameters{
+                to: msg.response_destination,
+                value: 0,
+                bounce: false,
+                mode: SendRemainingValue + SendIgnoreErrors
+            });
+        }
+    }
+
+    //*********************************//
+    //             Getters             //
+    //*********************************//
+
+    // @dev get_jetton_data retrieve information of this jetton
+    get fun get_jetton_data(): JettonData {
+        return JettonData{
+            total_supply: self.total_supply,
+            mintable: self.mintable,
+            admin_address: self.owner,
+            jetton_content: self.jetton_content,
+            jetton_wallet_code: self.calculate_jetton_wallet_init(myAddress()).code
+        };
+    }
+
+    // @dev get_wallet_address call calculate_jetton_wallet_init and return address of wallet
+    get fun get_wallet_address(owner_address: Address): Address {
+        let initCode: StateInit = self.calculate_jetton_wallet_init(owner_address);
+        return contractAddress(initCode);
+    }
+}

--- a/contracts/packages/token/jetton/JettonWallet.tact
+++ b/contracts/packages/token/jetton/JettonWallet.tact
@@ -1,0 +1,248 @@
+/*
+    This file provides traits for TEP-0074 jetton standard
+
+    [TEP0074](https://github.com/ton-blockchain/TEPs/blob/master/text/0074-jettons-standard.md)
+    [Official FunC implementation](https://github.com/ton-blockchain/token-contract/blob/main/ft/jetton-wallet.fc)
+    [Ton Minter Contract](https://github.com/ton-blockchain/minter-contract)
+    [Tact Template](https://github.com/howardpen9/jetton-implementation-in-tact/blob/main/sources/contract.tact)
+*/
+
+message(0x0f8a7ea5) JettonTransfer {
+    query_id: Int as uint64;                // arbitrary request number
+    amount: Int as coins;                   // amount of jettons to transfer
+    destination: Address;                   // address of the new owner of the jettons
+    response_destination: Address;          // address where to send a response with confirmation of a successful transfer and the rest of the incoming message Toncoins.
+    custom_payload: Cell?;                  // optional custom payload
+    forward_ton_amount: Int as coins;       // the amount of nanotons to be sent to the destination address.
+    forward_payload: Slice as remaining;    // optional custom data that should be sent to the destination address.
+}
+
+message(0x7362d09c) JettonTransferNotification {
+    query_id: Int as uint64;                // arbitrary request number
+    amount: Int as coins;                   // amount of jettons to transfer
+    sender: Address;                        // address of the sender of the jettons
+    forward_payload: Slice as remaining;    // optional custom payload
+}
+
+message(0x595f07bc) JettonBurn {
+    query_id: Int as uint64;        // arbitrary request number
+    amount: Int as coins;           // amount of jettons to burn
+    response_destination: Address;  // address where to send a response with confirmation of a successful burn and the rest of the incoming message coins.
+    custom_payload: Cell?;          // optional custom payload
+}
+
+message(0xd53276db) JettonExcesses {
+    query_id: Int as uint64;        // arbitrary request number
+}
+
+message(0x178d4519) JettonInternalTransfer {
+    query_id: Int as uint64;                // arbitrary request number
+    amount: Int as coins;                   // amount of jettons to transfer
+    from: Address;                          // address of the sender of the jettons 
+    response_address: Address;              // address where to send a response with confirmation of a successful transfer and the rest of the incoming message coins.
+    forward_ton_amount: Int as coins;       // the amount of nanotons to be sent to the destination address.
+    forward_payload: Slice as remaining;    // optional custom data that should be sent to the destination address.
+}
+
+message(0x7bdd97de) JettonBurnNotification {
+    query_id: Int as uint64;          // arbitrary request number
+    amount: Int as coins;             // amount of jettons to burn
+    sender: Address;                  // address of the sender of the jettons
+    response_destination: Address;    // address where to send a response with confirmation of a successful burn and the rest of the incoming message coins.
+}
+
+struct WalletData {
+    balance: Int as coins;      // amount of jettons on wallet
+    owner: Address;             // address of wallet owner;
+    jetton: Address;            // address of Jetton master-address
+    jetton_wallet_code: Cell;   // with code of this wallet
+}
+
+
+trait JettonWallet {
+    balance: Int;
+    owner: Address;
+    jetton_master: Address;
+    virtual const gasConsumption: Int = ton("0.05");
+    virtual const minTonsForStorage: Int = ton("0.05");
+
+    //********************************************//
+    //                  Messages                  //
+    //********************************************//
+
+    // @dev  JettonTransfer is send from the owner of the jetton wallet to the jetton wallet itself to transfer jettons to another user
+    receive(msg: JettonTransfer) {
+        let ctx: Context = context();
+        self.balance = self.balance - msg.amount;
+        require(self.balance >= 0, "JettonWallet: Not enough jettons to transfer");
+        self._transfer_validate(ctx, msg);
+        self._transfer_estimate_remain_value(ctx, msg);
+        self._transfer_jetton(ctx, msg);
+    }
+
+    // @dev  JettonBurn is send from the owner of the jetton wallet to the jetton wallet itself to burn jettons
+    receive(msg: JettonBurn) {
+        let ctx: Context = context();
+        self.balance = self.balance - msg.amount;
+        require(self.balance >= 0, "JettonWallet: Not enough balance to burn tokens");
+        self._burn_validate(ctx, msg);
+        self._burn_tokens(ctx, msg);
+    }
+
+    // @dev  JettonInternalTransfer is send from the jetton master or jetton wallet to the jetton wallet itself to transfer jettons to this jetton wallet
+    receive(msg: JettonInternalTransfer) {
+        let ctx: Context = context();
+        self.balance = self.balance + msg.amount;
+        require(self.balance >= 0, "JettonWallet: Not allow negative balance after internal transfer");
+        self._internal_transfer_validate(ctx, msg);
+        let remain: Int = self._internal_transfer_estimate_remain_value(ctx, msg);
+        if (msg.forward_ton_amount > 0){
+            self._internal_transfer_notification(ctx, msg);
+        }
+        self._internal_transfer_excesses(ctx, msg, remain);
+    }
+
+    bounced(src: bounced<JettonInternalTransfer>) {
+        self.balance = self.balance + src.amount;
+    }
+
+    bounced(src: bounced<JettonBurnNotification>) {
+        self.balance = self.balance + src.amount;
+    }
+
+
+    //********************************************//
+    //             Internal functions             //
+    //********************************************//
+
+    // @dev  calculate_jetton_wallet_init will get init code of a jetton wallet by provided it's owner address
+    // @note one MUST override this function and return state init of the inherited jetton wallet implementation
+    abstract inline fun calculate_jetton_wallet_init(owner_address: Address): StateInit;
+
+    // @dev  _internal_tranfer_validate will validate internal transfer message, usually it will check that sender is a jetton master or jetton wallet
+    // @note this function will triggered on receiving JettonTransfer message
+    virtual inline fun _internal_transfer_validate(ctx: Context, msg: JettonInternalTransfer) {
+        if(ctx.sender != self.jetton_master){
+            let init: StateInit = self.calculate_jetton_wallet_init(msg.from);
+            require(ctx.sender == contractAddress(init), "JettonWallet: Only Jetton master or Jetton wallet can call this function");
+        }
+    }
+
+    // @dev  _internal_transfer_estimate_remain_value will estimate remain value after deducting storage fee, forward fee and gas consumption
+    virtual inline fun _internal_transfer_estimate_remain_value(ctx: Context, msg: JettonInternalTransfer): Int {
+        let tonBalanceBeforeMsg: Int = myBalance() - ctx.value;
+        let storage_fee: Int =  self.minTonsForStorage - min(tonBalanceBeforeMsg, self.minTonsForStorage);
+        let remain: Int = ctx.value - (storage_fee + self.gasConsumption);
+        if (msg.forward_ton_amount > 0) {
+            remain = remain - (ctx.readForwardFee() + msg.forward_ton_amount);
+        }
+        return remain;
+    }
+
+    // @dev  _internal_transfer_notification will send notification to the owner of the jetton wallet
+    virtual inline fun _internal_transfer_notification(ctx: Context, msg: JettonInternalTransfer) {
+        if (msg.forward_ton_amount > 0) {
+            send(SendParameters{
+                to: self.owner,
+                value: msg.forward_ton_amount,
+                mode: SendPayGasSeparately,
+                bounce: false,
+                body: JettonTransferNotification{
+                    query_id: msg.query_id,
+                    amount: msg.amount,
+                    sender: msg.from,
+                    forward_payload: msg.forward_payload
+                }.toCell()
+            });
+        }
+    }
+
+    // @dev  _internal_transfer_excesses will send excesses message back after transfer action completed
+    virtual inline fun _internal_transfer_excesses(ctx: Context, msg: JettonInternalTransfer, remain: Int){
+        if((msg.response_address != newAddress(0, 0)) && remain > 0){
+            send(SendParameters{
+                to: msg.response_address,
+                value: remain,
+                bounce: false,
+                mode: SendIgnoreErrors,
+                body: JettonExcesses{
+                    query_id: msg.query_id
+                }.toCell()
+            });
+        }
+    }
+    
+    // @dev  _burn_validate will conduct custom checking when receiving JettonBurn message
+    virtual inline fun _burn_validate(ctx: Context, msg: JettonBurn) {
+        require(ctx.sender == self.owner, "JettonWallet: Only owner can burn tokens");
+    }
+
+    // @dev  _burn_tokens will burn tokens and send JettonBurnNotification back to the jetton master
+    // @note this message is bounceable, if burn action failed, the message will be bounced back, you should increase the balance of the wallet
+    virtual inline fun _burn_tokens(ctx: Context, msg: JettonBurn) {
+        send(SendParameters{
+            to: self.jetton_master,
+            value: 0,
+            mode: SendRemainingValue,
+            bounce: true,
+            body: JettonBurnNotification{
+                query_id: msg.query_id,
+                amount: msg.amount,
+                sender: self.owner,
+                response_destination: msg.response_destination
+            }.toCell()
+        });
+    }
+
+    // @dev  _transfer_validate will conduct custom checking when receiving JettonTransfer message
+    virtual inline fun _transfer_validate(ctx: Context, msg: JettonTransfer) {
+        require(ctx.sender == self.owner, "Only owner can call this function");
+        
+    }
+
+    // @dev  _transfer_estimate_remain_value will estimate remain value after deducting storage fee, forward fee and gas consumption
+    virtual inline fun _transfer_estimate_remain_value(ctx: Context, msg: JettonTransfer) {
+        let fwd_count: Int = 1;
+        if (msg.forward_ton_amount > 0) {
+            fwd_count = 2;
+        }
+        require(ctx.value > fwd_count * ctx.readForwardFee() + 2 * self.gasConsumption + self.minTonsForStorage, "Not enough funds to transfer");
+    }
+
+    // @dev  _transfer_jetton will transfer jettons to the jetton wallet of the destination address (owner of jetton wallet)
+    // @note  this message is bounceable, if transfer action failed, the message will be bounced back, you should increase the balance of the wallet
+    virtual inline fun _transfer_jetton(ctx: Context, msg: JettonTransfer) {
+        let init: StateInit = self.calculate_jetton_wallet_init(msg.destination);
+        let receiver: Address = contractAddress(init);
+        send(SendParameters{
+            to: receiver,
+            value: 0,
+            bounce: true,
+            mode: SendRemainingValue,
+            body: JettonInternalTransfer{
+                query_id: msg.query_id,
+                amount: msg.amount,
+                response_address: msg.response_destination,
+                from: self.owner,
+                forward_ton_amount: msg.forward_ton_amount,
+                forward_payload: msg.forward_payload
+            }.toCell(),
+            code: init.code,
+            data: init.data
+        });
+    }
+
+    //*********************************//
+    //             Getters             //
+    //*********************************//
+
+    // @dev  get_wallet_data will return wallet data, which follows TEP 0074 standard
+    get fun get_wallet_data(): WalletData{
+        return WalletData { 
+            balance: self.balance,
+            owner: self.owner,
+            jetton: self.jetton_master,
+            jetton_wallet_code: self.calculate_jetton_wallet_init(self.owner).code
+        };
+    }    
+}

--- a/contracts/packages/token/nft/AuctionErrorCode.tact
+++ b/contracts/packages/token/nft/AuctionErrorCode.tact
@@ -1,0 +1,55 @@
+/* 
+    NFT Auciton Market Error Code :
+    3724: Bid doesn't meet the minimum increase requirement
+    11017: Contract is already initialized
+    19941: Only owner can build nft auction contract
+    20805: Only owner can init auction end time.
+    20844: BuyNowPrice must be greater than reservePrice
+    24136: Auction was not set before.
+    37031: NFT Seller cannot bid
+    42237: Contract is not initialized
+    42345: Only owner can revise auction contract
+    45065: Auction not yet ended
+    46984: Auction ended
+    50905: Auction bid period ended
+    54143: This NFT didn't transfer to NFT Auction Market Contract yet.
+    55234: BuyNowPrice must be greater than reservePrice.
+    58706: Auction was already set for this NFT.
+    59374: Cannot update reserve price and buy now price at the same time.
+*/
+
+/* 
+    NFT Auction Error Code :
+    3724: Bid doesn't meet the minimum increase requirement
+    11017: Contract is already initialized
+    19941: Only owner can build nft auction contract
+    20805: Only owner can init auction end time.
+    20844: BuyNowPrice must be greater than reservePrice
+    24136: Auction was not set before.
+    37031: NFT Seller cannot bid
+    42237: Contract is not initialized
+    42345: Only owner can revise auction contract
+    45065: Auction not yet ended
+    46984: Auction ended
+    50905: Auction bid period ended
+    54143: This NFT didn't transfer to NFT Auction Market Contract yet.
+    55234: BuyNowPrice must be greater than reservePrice.
+    58706: Auction was already set for this NFT.
+    59374: Cannot update reserve price and buy now price at the same time.
+*/
+
+/* 
+    Error code Old Version :
+    1000: Auction not yet ended.
+    1001: Only owner can do this.
+    1002: Auction was not set before.
+    1003: This NFT didn't transfer to NFT Auction Market Contract yet.
+    1004: Contract is already initialized.
+    1005: Auction ended.
+    1006: NFT Seller cannot bid.
+    1007: Bid doesn't meet the minimum increase requirement.
+    1008: Auction was already set for this NFT.
+    1009: Auction did not set up before.
+    1010: BuyNowPrice must be greater than reservePrice.
+    1011: Cannot update reserve price and buy now price at the same time.
+*/

--- a/contracts/packages/token/nft/NFTAuction.tact
+++ b/contracts/packages/token/nft/NFTAuction.tact
@@ -1,0 +1,226 @@
+/*
+    This file provides traits for the NFT Auction contract, allowing users to bid on NFTs. 
+    When the auction ends, the NFT goes to the highest bidder and the seller receives the bid amount. 
+
+    Reference:
+    [Official Implementation](https://github.com/ton-blockchain/token-contract/blob/991bdb4925653c51b0b53ab212c53143f71f5476/nft/nft-marketplace.fc)
+    [Official Implementation](https://github.com/ton-blockchain/token-contract/blob/991bdb4925653c51b0b53ab212c53143f71f5476/nft/nft-sale.fc)
+    [NFT Auction Template](https://github.com/avolabs-io/nft-auction)
+*/
+
+trait NFTAuctionStandard {
+    virtual const minTonsForStorage: Int = ton("0.03");
+    virtual const gasConsumption: Int = ton("0.03");
+
+    owner: Address;
+    nftAddress: Address;
+    seller: Address;
+    auctionInfo: AuctionInfo;
+    auctionBidPeriod: Int;
+    isInitialized: Int;
+    auctionEndTime: Int;
+
+    //********************************************//
+    //                  Messages                  //
+    //********************************************//
+
+    // @dev Default receive function to receive funds
+    receive() {}
+
+    // @dev Initializes the auction when called by the owner
+    receive(msg: BuildNftAuction) {
+        let ctx: Context = context();
+        require(ctx.sender == self.owner, "Only owner can build nft auction contract");
+        require(self.isInitialized == 0, "Contract is already initialized");
+        require(msg.auctionInfo.buyNowPrice > msg.auctionInfo.reservePrice, "BuyNowPrice must be greater than reservePrice");
+        self.auctionInfo = msg.auctionInfo;
+        self.isInitialized = 1;
+        self.auctionBidPeriod = 0;
+        self.auctionEndTime = 0;
+    }
+
+    // @dev Accepts bids for the NFT as long as the auction is active
+    receive("Bid") {
+        // Check if auction is still active.
+        require(now() < self.auctionEndTime || self.auctionEndTime == 0, "Auction ended");
+        require(self.isInitialized == 1, "Contract is not initialized");
+        require(now() < self.auctionBidPeriod | self.auctionBidPeriod ==0, "Auction bid period ended");
+
+        let ctx: Context = context();
+        let buyer: Address = ctx.sender;
+        require(buyer != self.auctionInfo.nftSeller, "NFT Seller cannot bid");
+        let bidValue: Int = ctx.value;
+        let buyNowPrice: Int = self.auctionInfo.buyNowPrice;
+        if(bidValue >= buyNowPrice) {
+            self.auctionInfo.nftHighestBid = bidValue;
+            // Pay winning bid amount to seller.
+            self._send_winning_bid_amount();
+            // Transfer NFT to buyer
+            self._transfer_nft(buyer);
+            self.isInitialized = 0;
+            return;
+        }
+
+        let bidIncreaseAmount: Int = (self.auctionInfo.nftHighestBid * (10000 + self.auctionInfo.bidIncreasePercentage)) / 10000;
+        require(bidValue > bidIncreaseAmount, "Bid doesn't meet the minimum increase requirement");
+        // Send back previous highest bid to previous highest bidder.
+        let prevNftHighestBidder: Address = self.auctionInfo.nftHighestBidder;
+        let prevNftHighestBid: Int = self.auctionInfo.nftHighestBid;
+        let paybackTon: Int = max(prevNftHighestBid - self.minTonsForStorage - self.gasConsumption,0);
+        send(SendParameters{
+            to: prevNftHighestBidder,
+            value: paybackTon, 
+            mode: SendPayGasSeparately, 
+            bounce: false,
+            body: "Pay bid money back to the prevNftHighestBidder".asComment()
+        });
+        // Update highest bid and Transfer ton back to previous highest bidder.
+        self.auctionInfo.nftHighestBidder = ctx.sender;
+        self.auctionInfo.nftHighestBid = bidValue;
+        // If bid value is greater than reserve price, then the auction is being started.
+        if(bidValue > self.auctionInfo.reservePrice) {
+            self._update_auction_bid_period();
+            if(self.auctionEndTime == 0) { 
+                // If the auction start, then set the auction end time.
+                self._update_auction_end_time();
+            }
+        }
+    }
+
+    // @dev Settles the auction, transferring the NFT to the highest bidder and the funds to the seller
+    receive("settleAuction") {
+        require(now() >= self.auctionBidPeriod, "Auction not yet ended");
+        // Pay winning bid amount to seller.
+        self._send_winning_bid_amount();
+
+        // Transfer NFT to buyer
+        let buyer: Address = self.auctionInfo.nftHighestBidder;
+        self._transfer_nft(buyer);
+        self.isInitialized = 0;
+    }
+
+    // @dev Allows owner to adjust auction's reserve or buy-now prices.
+    receive(msg: ReviseAuction) {
+        let ctx: Context = context();
+        require(ctx.sender == self.owner, "Only owner can revise auction contract");
+        require(self.auctionInfo.reservePrice == msg.reviseAuctionInfo.reservePrice || msg.reviseAuctionInfo.buyNowPrice == self.auctionInfo.buyNowPrice, "Cannot update reserve price and buy now price at the same time.");
+
+        // Update the reserve price of the auction.
+        // This can only be done if no bid has been made that already exceeds the original minimum price.
+        if(self.auctionEndTime == 0 && self.auctionInfo.reservePrice != msg.reviseAuctionInfo.reservePrice && msg.reviseAuctionInfo.reservePrice < self.auctionInfo.buyNowPrice) {
+
+            self.auctionInfo.reservePrice = msg.reviseAuctionInfo.reservePrice;
+            if(self.auctionInfo.nftHighestBid > self.auctionInfo.reservePrice) {
+                self._update_auction_bid_period();
+                self._update_auction_end_time();
+            }
+        }
+        // Update the buy now price of the auction.
+        // This can only be done if no bid has been made that already exceeds the original minimum price.
+        if(self.auctionEndTime == 0 && msg.reviseAuctionInfo.buyNowPrice != self.auctionInfo.buyNowPrice && msg.reviseAuctionInfo.buyNowPrice > self.auctionInfo.reservePrice) {
+            self.auctionInfo.buyNowPrice = msg.reviseAuctionInfo.buyNowPrice;
+        }
+    }
+
+    // @dev Ends the auction and transfers the NFT to the highest bidder or back to the seller(If autcion not started)
+    receive("EndAuction") {
+        // If this auction started, it will transfer NFT to highest bidder.
+        // Else, it will transfer NFT to seller.
+        if(self.auctionEndTime > 0) {
+            // Pay royalty to the creator of the NFT
+            // TODO: Implement royalty payment
+            
+            // Pay winning bid amount to seller.
+            self._send_winning_bid_amount();
+            // Transfer NFT to buyer
+            let buyer: Address = self.auctionInfo.nftHighestBidder;
+            self._transfer_nft(buyer);
+            self.isInitialized = 0;
+        }
+        else {
+            // Transfer NFT to seller
+            let seller: Address = self.auctionInfo.nftSeller;
+            self._transfer_nft(seller);
+            self.isInitialized = 0;
+        }
+    }
+
+    //********************************************//
+    //             Internal functions             //
+    //********************************************//
+
+    // @dev Updates the auction bid period time based on the latest bid and the defined auction bid period
+    virtual inline fun _update_auction_bid_period() {
+        self.auctionBidPeriod = now() + self.auctionInfo.auctionBidPeriod;
+    }
+
+    // @dev Updates the auction end time
+    virtual inline fun _update_auction_end_time() {
+        self.auctionEndTime = now() + self.auctionInfo.auctionPeriod;
+    }
+
+    // @dev Transfer the NFT to the highest bidder
+    // @note If you want change msg value, you should make sure that is enough for NFT Auction market contract to transfer NFT.
+    virtual inline fun _transfer_nft(buyer: Address) {
+        send(SendParameters{
+            to: self.owner, 
+            value: ton("0.06"), 
+            bounce: true,
+            mode: SendPayGasSeparately,
+            body: TransferNFT {
+                nftAddress: self.nftAddress,
+                seller: self.auctionInfo.nftSeller,
+                query_id: 0,
+                new_owner: buyer,
+                response_destination: buyer,
+                custom_payload: emptyCell(),
+                forward_amount: 0,
+                forward_payload: emptySlice()
+            }.toCell()
+        });
+    }
+
+    // @dev Transfers the highest bid amount to the seller
+    virtual inline fun _send_winning_bid_amount() {
+        let seller: Address = self.auctionInfo.beneficiary;
+        let winningBidAmount: Int = self.auctionInfo.nftHighestBid;
+        send(SendParameters{
+            to: seller,
+            value: winningBidAmount - ton("0.06"), 
+            mode: SendPayGasSeparately, 
+            bounce: false,
+            body: "Pay winning bid amount".asComment()
+        });
+    }
+
+    // @dev Initializes the auction end time to 0, allowing the seller to auction the NFT again in the future
+    virtual inline fun _init_auction_end() {
+        let ctx: Context = context();
+        require(ctx.sender == self.owner, "Only owner can init auction end time.");
+        self.auctionBidPeriod = 0;
+    }
+
+    //*********************************//
+    //             Getters             //
+    //*********************************//
+
+    // @dev Returns the current auction information
+    get fun get_auctin_info(): AuctionInfo {
+        return self.auctionInfo;
+    }
+
+    // @dev Checks if the auction is initialized and returns the state (1 for initialized, 0 otherwise)
+    get fun get_is__initialized(): Int {
+        return self.isInitialized;
+    }
+
+    // @dev Returns the end time of the auction
+    get fun get_auction_end(): Int {
+        return self.auctionEndTime;
+    }
+
+    // @dev Retruns the auction bid period
+    get fun get_auction_bid_period(): Int {
+        return self.auctionBidPeriod;
+    }
+}

--- a/contracts/packages/token/nft/NFTAuctionMarket.tact
+++ b/contracts/packages/token/nft/NFTAuctionMarket.tact
@@ -1,0 +1,302 @@
+/*
+    This file provides traits for NFT auction market which can be easily used in a permissionless and flexible manner to auction (or simply buy/sell) NFTs. 
+    Sellers and bidders are able to make customized auctions and bids that allow for a holistic NFT auction/sale mechanism.
+
+    Reference:
+    [Official Implementation](https://github.com/ton-blockchain/token-contract/blob/991bdb4925653c51b0b53ab212c53143f71f5476/nft/nft-marketplace.fc)
+    [Official Implementation](https://github.com/ton-blockchain/token-contract/blob/991bdb4925653c51b0b53ab212c53143f71f5476/nft/nft-sale.fc)
+    [NFT Auction Template](https://github.com/avolabs-io/nft-auction)
+*/
+import "./NFTItem";
+
+message SetUpAuction {
+    nftAddress: Address;            // NFT address to be auctioned
+    reservePrice: Int as coins;     // minimum bid price to start the auction timer
+    buyNowPrice: Int as coins;      // price at which the NFT can be directly bought
+    auctionPeriod: Int as uint256;  // time when the auction ends after it starts
+    beneficiary: Address?;           // the address of the beneficiary
+}
+
+message ReviseSetUpAuction {
+    nftAddress: Address;            // NFT address to be auctioned
+    reservePrice: Int as coins;     // minimum bid price to start the auction timer
+    buyNowPrice: Int as coins;      // price at which the NFT can be directly bought
+    auctionPeriod: Int as uint256;  // time when the auction ends after it starts
+    beneficiary: Address?;           // the address of the beneficiary
+    // TODO: beneficiary: Address?;           // the address of the beneficiary
+}
+
+message ReviseAuction {
+    reviseAuctionInfo: AuctionInfo;
+}
+
+message BuildNftAuction {
+    auctionInfo: AuctionInfo;
+}
+
+message EndAuction {
+    nftAddress: Address;    
+}
+
+// @dev This message is used to ask NFT auction market contract to transfer NFT to the new owner
+message TransferNFT {
+    nftAddress: Address;
+    seller: Address;
+    query_id: Int as uint64;            
+    new_owner: Address; 
+    response_destination: Address; 
+    custom_payload: Cell?; 
+    forward_amount: Int as coins; 
+    forward_payload: Slice as remaining;  
+}
+
+// @dev This struct is used to store auction information
+// @note If you want to use custom auction parameters or logic, consider overriding this struct and setUpAuction function in a derived contract
+struct AuctionInfo {
+    bidIncreasePercentage: Int as uint256;  // the minimum percentage by which a new bid must exceed the current highest bid
+    auctionBidPeriod: Int as uint256;       // increments the length of time the auction is open in which a new bid can be made after each bid
+    auctionPeriod: Int as uint256;          // the time at which the auction will end
+    reservePrice: Int as coins;             // the minimum price that must be paid for the NFT
+    buyNowPrice: Int as coins;              // the price that must be paid for the NFT if the buyer chooses to buy it now
+    nftHighestBid: Int as coins;            // the highest bid that has been made so far
+    nftHighestBidder: Address;              // the address of the bidder who has made the highest bid so far
+    nftSeller: Address;                     // the address of the seller
+    whitelistedBuyer: Address;              // the seller can specify a whitelisted address for a sale (this is effectively a direct sale)
+    nftRecipient: Address;                  // the bidder can specify a recipient for the NFT if their bid is successful
+    beneficiary: Address;                  // the address of the beneficiary
+}
+
+trait NFTAuctionMarketStandard {
+    owner: Address;
+    // Check whether nft is transfered to NFT Auction Market Contract
+    auctionTransferCheck: map<Int, Int>; // key => hash(sellerAddress and nftAddress), vlaue => 1: set, 0: not set
+    // Check whether nft auction is over or not
+    auctionOverCheck: map<Address, Address>;  // key => nft auction contract address, value => 1: not over, 0: over
+
+    // @dev Default parameters for setting up an NFT auction
+    virtual const defaultBidIncreasePercentage: Int = 100;
+    virtual const defaultAuctionBidPeriod: Int = 86400; // 1 day
+    virtual const minimumSettableIncreasePercentage: Int = 100;
+    virtual const maximumMinPricePercentage: Int = 8000;
+
+    //********************************************//
+    //                  Messages                  //
+    //********************************************//
+
+    // Default receive function to receive funds
+    receive() {}
+    
+    // @dev Processes the OwnershipAssigned message and updates auction mappings,
+    //      and confirms NFT transfer to the Auction Market.
+    receive(msg: OwnershipAssigned) {
+        let ctx: Context = context();
+        let prev_owner: Address = msg.prev_owner; // Seller Address
+        let nftAddress: Address = ctx.sender;
+        let hashSellerNftAddress: Int = self.get_hash_seller_nft_address(prev_owner, nftAddress);
+        // Set nft transfer checking to 1
+        self.auctionTransferCheck.set(hashSellerNftAddress, 1);
+        let payload: Slice = msg.forward_payload;
+        
+        if(payload.empty() == false) {  
+            self._parse_forward_payload(prev_owner, nftAddress, payload);
+        }
+    }
+
+    // @dev Handles the receipt of a SetUpAuction message.
+    //      First, it verifies if the NFT has been transferred to the NFT Auction Market Contract.
+    //      Upon successful validation, it sets up the auction for the specified NFT and deploys 
+    //      a new NFT Auction Contract instance for it.
+    receive(msg: SetUpAuction) {
+        let ctx: Context = context();
+        let sellerAddress: Address = ctx.sender;
+        let hashSellerNftAddress: Int = self.get_hash_seller_nft_address(sellerAddress, msg.nftAddress);
+        self._auction_transfer_validate(hashSellerNftAddress);
+        if(msg.beneficiary == null) {
+            msg.beneficiary = sellerAddress;
+        }
+        // Set up auction info
+        let auctionInfo: AuctionInfo = self._set_up_auction(sellerAddress, msg.nftAddress, msg.reservePrice, msg.buyNowPrice, msg.auctionPeriod, msg.beneficiary!!); // set up auction
+        self._set_price_validate(msg.buyNowPrice, msg.reservePrice);
+        let nftAuctionInit: StateInit = self._nft_auction_init(msg.nftAddress, sellerAddress);
+        let nftAuctionAddress: Address = self.get_nft_auction_address(msg.nftAddress, sellerAddress);
+        self._auction_set_validate(nftAuctionAddress);
+        self.auctionOverCheck.set(nftAuctionAddress, msg.nftAddress);
+
+        // Deploy a new NFT Auction Contract
+        self._build_auction(nftAuctionAddress, auctionInfo, nftAuctionInit);
+    }
+
+    // @dev Handles the TransferNFT message and facilitates NFT transfer to the auction's winning bidder.
+    receive(msg: TransferNFT) {
+        let ctx: Context = context();
+        let nftAuctionAddress: Address = ctx.sender;
+        self._auction_not_set_validate(nftAuctionAddress);
+        send(SendParameters{
+            to: msg.nftAddress, 
+            value: 0, 
+            bounce: false,
+            mode: SendRemainingValue,
+            body: Transfer {
+                query_id: msg.query_id,
+                new_owner: msg.new_owner,
+                response_destination: msg.response_destination,
+                custom_payload: msg.custom_payload,
+                forward_amount: msg.forward_amount,
+                forward_payload: msg.forward_payload
+            }.toCell()
+        });
+        self.auctionOverCheck.set(ctx.sender, null);
+        let hashSellerNftAddress: Int = self.get_hash_seller_nft_address(msg.seller, msg.nftAddress);
+        self.auctionTransferCheck.set(hashSellerNftAddress, null);
+    }
+
+    // @dev Updates auction details after verifying NFT transfer and previous auction setup, then communicates the update to the nftAuctionAddress.
+    receive(msg: ReviseSetUpAuction) {
+        let ctx: Context = context();
+        let sellerAddress: Address = ctx.sender;
+        let hashSellerNftAddress: Int = self.get_hash_seller_nft_address(sellerAddress, msg.nftAddress);
+        self._auction_transfer_validate(hashSellerNftAddress);
+        // Get nft auction address
+        let nftAuctionAddress: Address = self.get_nft_auction_address(msg.nftAddress, sellerAddress);
+        self._auction_not_set_validate(nftAuctionAddress);
+        if(msg.beneficiary == null) {
+            msg.beneficiary = sellerAddress;
+        }
+        // Set up auction info
+        let auctionInfo: AuctionInfo = self._set_up_auction(sellerAddress, msg.nftAddress, msg.reservePrice, msg.buyNowPrice, msg.auctionPeriod, msg.beneficiary!!); // set up auction
+        self.auctionOverCheck.set(nftAuctionAddress, msg.nftAddress);
+        let newAuctionInfo: AuctionInfo = self._set_up_auction(sellerAddress, msg.nftAddress, msg.reservePrice, msg.buyNowPrice, msg.auctionPeriod, msg.beneficiary!!); // set up auction
+        send(SendParameters{
+                to: nftAuctionAddress,
+                value: 0,
+                mode: SendRemainingValue,
+                bounce: false,
+                body: ReviseAuction {
+                    reviseAuctionInfo: newAuctionInfo
+                }.toCell()
+            }
+        );
+    }
+
+    // @dev Allows the seller to terminate an auction. 
+    //      It verifies if the auction was previously set and then sends a message to the nftAuctionAddress to conclude the auction.
+    //      It will transfer the NFT to the highest bidder or back to the seller(If autcion not started).
+    receive(msg: EndAuction) {
+        // Seller can end auction.
+        let ctx: Context = context();
+        let sellerAddress: Address = ctx.sender;
+        let hashSellerNftAddress: Int = self.get_hash_seller_nft_address(sellerAddress, msg.nftAddress);
+        let nftAuctionAddress: Address = self.get_nft_auction_address(msg.nftAddress, sellerAddress);
+        self._auction_not_set_validate(nftAuctionAddress);
+        send(SendParameters{
+                to: nftAuctionAddress,
+                value: 0,
+                mode: SendRemainingValue,
+                bounce: false,
+                body: "EndAuction".asComment()
+            }
+        );
+    }
+
+    //********************************************//
+    //             Internal functions             //
+    //********************************************//
+
+    virtual inline fun _parse_forward_payload(seller: Address, nftAddress: Address, payload: Slice) {
+        // Parse payload
+        let beneficiary: Address = payload.loadAddress();
+        let reservePrice: Int = payload.loadCoins();
+        let buyNowPrice: Int = payload.loadCoins();
+        let auctionPeriod: Int = payload.loadUint(256);
+
+        // Set up auction info
+        let auctionInfo: AuctionInfo = self._set_up_auction(seller, nftAddress, reservePrice, buyNowPrice, auctionPeriod, beneficiary); // set up auction
+        self._set_price_validate(buyNowPrice, reservePrice);
+        let nftAuctionInit: StateInit = self._nft_auction_init(nftAddress, seller);
+        let nftAuctionAddress: Address = self.get_nft_auction_address(nftAddress, seller);
+        self._auction_set_validate(nftAuctionAddress);
+        self.auctionOverCheck.set(nftAuctionAddress, nftAddress);
+
+        // Deploy a new NFT Auction Contract
+        self._build_auction(nftAuctionAddress, auctionInfo, nftAuctionInit);
+    }
+
+    virtual inline fun _build_auction(nftAuctionAddress: Address, auctionInfo: AuctionInfo, nftAuctionInit: StateInit) {
+        send(SendParameters{
+                to: nftAuctionAddress,
+                value: 0,
+                mode: SendRemainingValue,
+                bounce: false,
+                body: BuildNftAuction {
+                    auctionInfo: auctionInfo
+                }.toCell(),
+                code: nftAuctionInit.code, 
+                data: nftAuctionInit.data
+            }
+        );
+    }
+    
+    virtual inline fun _set_price_validate(buyNowPrice: Int, reservePrice: Int) {
+        require(buyNowPrice > reservePrice, "BuyNowPrice must be greater than reservePrice.");
+    }
+
+    virtual inline fun _auction_set_validate(nftAuctionAddress: Address) {
+        require(self.auctionOverCheck.get(nftAuctionAddress) == null, "Auction was already set for this NFT.");
+    }
+
+    virtual inline fun _auction_not_set_validate(nftAuctionAddress: Address) {
+        require(self.auctionOverCheck.get(nftAuctionAddress) != null, "Auction was not set before.");
+    }
+
+    virtual inline fun _auction_transfer_validate(hashSellerNftAddress: Int) {
+        require(self.get_is_auction_transfer_check(hashSellerNftAddress) == 1, "This NFT didn't transfer to NFT Auction Market Contract yet.");
+    }
+
+    // @dev Initializes an auction for a specified NFT with given parameters such as reserve price, buy now price, and auction duration.
+    // @note If you want to use custom auction parameters or logic, consider overriding this function and AuctionInfo struct in a derived contract.
+    virtual inline fun _set_up_auction(sellerAddress: Address, nftAddress: Address, reservePrice: Int, buyNowPrice: Int, auctionPeriod: Int, beneficiary: Address): AuctionInfo {
+        let hashSellerNftAddress: Int = self.get_hash_seller_nft_address(sellerAddress, nftAddress);
+        return AuctionInfo {
+            bidIncreasePercentage: self.defaultBidIncreasePercentage,
+            auctionBidPeriod: self.defaultAuctionBidPeriod,
+            auctionPeriod: auctionPeriod,
+            reservePrice: reservePrice,
+            buyNowPrice: buyNowPrice,
+            nftHighestBid: 0,
+            nftHighestBidder: sellerAddress,
+            nftSeller: sellerAddress,
+            whitelistedBuyer: sellerAddress,
+            nftRecipient: sellerAddress,
+            beneficiary: beneficiary
+        };
+    }
+
+    // @dev Retrieves the initial state for the NFT auction contract.
+    // @note one MUST override this function to provide NFT Auction initCode
+    abstract fun _nft_auction_init(nftAddress: Address, seller: Address): StateInit;
+
+    //*********************************//
+    //             Getters             //
+    //*********************************//
+
+    // @dev Determines the NFT auction contract address.
+    get fun get_nft_auction_address(nftAddress: Address, seller: Address): Address {
+        let nftAuctionInit: StateInit = self._nft_auction_init(nftAddress, seller);
+        return contractAddress(nftAuctionInit);
+    }
+
+    // @dev Generates a hash value based on the seller and NFT address.
+    get fun get_hash_seller_nft_address(seller: Address, nftAddress: Address): Int {
+        return beginCell().storeAddress(seller).storeAddress(nftAddress).endCell().asSlice().hash();
+    }
+
+    // @dev Checks if the auction transfer for a given hash is valid.
+    get fun get_is_auction_transfer_check(hashSellerNftAddress: Int): Int {
+        if(self.auctionTransferCheck.get(hashSellerNftAddress) == null) {
+            return 0;
+        }
+        else {
+            return 1;
+        }
+    }
+}

--- a/contracts/packages/token/nft/NFTCollection.tact
+++ b/contracts/packages/token/nft/NFTCollection.tact
@@ -1,0 +1,69 @@
+/*
+    This file provides traits for NFT collections which follows the TEP-0062 standard.
+    https://github.com/ton-blockchain/TEPs/blob/master/text/0062-nft-standard.md
+*/
+
+
+struct CollectionData {
+    next_item_index: Int;     // collection should issue NFT with sequential indexes starting from 1. -1 value implies non-sequential collections.
+    collection_content: Cell; // collection content format should comply with TEP64 
+    owner_address: Address;   // collection owner address, zero address if no owner
+}
+
+trait NFTCollectionStandard {
+    virtual const NFT_COLLECTION_STANDARD_METADATA: String = "meta.json";
+
+    next_item_index: Int;
+    collection_content: Cell;
+    owner_address: Address;
+
+    //********************************************//
+    //             Internal functions             //
+    //********************************************//
+
+    // @dev _get_nft_item_state_init calculates init code for NFT item contract by item index
+    // @note one MUST override this function to provide custom NFT item initCode
+    abstract inline fun _get_nft_item_state_init(index: Int): StateInit;
+
+    // @dev _get_nft_content gets the serial number of the NFT item of this collection and the individual content of this NFT item.
+    //      returns the full content of the NFT item in format that complies with standard TEP-64.
+    // @note one MUST override this function to provide full NFT item content
+    virtual inline fun _get_nft_content(index: Int, individual_content: Cell): Cell {
+        let builder: StringBuilder = beginString();
+        let idvStr: String = individual_content.asSlice().asString();
+        builder.append(idvStr);
+        return builder.toCell();
+    }
+
+    // @dev get_collection_data returns nft collection data
+    virtual inline fun _get_collection_data(): CollectionData {
+        let builder: StringBuilder = beginString();
+        let urlPrefix: String = self.collection_content.asSlice().asString();
+        builder.append(urlPrefix);
+        builder.append(self.NFT_COLLECTION_STANDARD_METADATA);
+        return CollectionData {
+            next_item_index: self.next_item_index,
+            collection_content: builder.toCell(),
+            owner_address: self.owner_address
+        };
+    }
+
+    //*********************************//
+    //             Getters             //
+    //*********************************//
+    
+    get fun get_collection_data(): CollectionData {
+        return self._get_collection_data();
+    }
+
+    // @dev get_nft_address_by_index gets the serial number of NFT item of this collection and returns its address
+    get fun get_nft_address_by_index(index: Int): Address {
+        let initCode: StateInit = self._get_nft_item_state_init(index);
+        return contractAddress(initCode);
+    }
+
+    // @dev get_nft_content calls _get_nft_content and returns the full content of the NFT item in format that complies with standard TEP-64.
+    get fun get_nft_content(index: Int, individual_content: Cell): Cell {
+        return self._get_nft_content(index, individual_content);
+    }
+}

--- a/contracts/packages/token/nft/NFTItem.tact
+++ b/contracts/packages/token/nft/NFTItem.tact
@@ -1,0 +1,181 @@
+/*
+    This file provides traits for NFT item which follows the TEP-0062 standard.
+    https://github.com/ton-blockchain/TEPs/blob/master/text/0062-nft-standard.md
+
+    Reference:
+    [Official Implementation](https://github.com/ton-blockchain/token-contract/blob/991bdb4925653c51b0b53ab212c53143f71f5476/nft/nft-item.fc#L17)
+    [NFT Template](https://github.com/howardpen9/nft-template-in-tact/blob/tutorial/sources/contract.tact)
+*/
+
+
+message(0x5fcc3d14) Transfer { 
+    query_id: Int as uint64;                    // arbitrary request number
+    new_owner: Address;                         // new owner of the NFT item
+    response_destination: Address;              // address where to send a response with confirmation of a successful transfer and the rest of the incoming message coins if not empty address
+    custom_payload: Cell?;                      // optional custom data
+    forward_amount: Int as coins;               // the amount of nanotons to be sent to the new owner
+    forward_payload: Slice as remaining;        // optional custom data that should be sent to the new owner
+}
+
+message(0x05138d91) OwnershipAssigned {
+    query_id: Int as uint64;
+    prev_owner: Address;
+    forward_payload: Slice as remaining;
+}
+
+message(0xd53276db) Excesses {
+    query_id: Int as uint64;
+}
+
+message(0x2fcb26a2) GetStaticData {
+    query_id: Int as uint64;
+}
+
+message(0x8b771735) ReportStaticData {
+    query_id: Int as uint64;
+    index: Int as uint256;
+    collection: Address;
+}
+
+struct NftData {
+    is_initialized: Bool;         // it should be `init`, but it is a reserved keyword in tact. if not zero, then this NFT is fully initialized and ready for interaction.
+    index: Int;                   // numerical index of this NFT in the collection. For collection-less NFT - arbitrary but constant value.
+    collection_address: Address;  // address of the smart contract of the collection to which this NFT belongs. For collection-less NFT this parameter should be addr_none
+    owner_address: Address;       // address of the current owner of this NFT
+    individual_content: Cell;     // if NFT has collection - individual NFT content in any format; if NFT has no collection - NFT content in format that complies with standard TEP-64
+}
+
+
+trait NFTItemStandard {
+    virtual const minTonsForStorage: Int = ton("0.05");
+    virtual const gasConsumption: Int = ton("0.05");
+
+    collection_address: Address;
+    index: Int;
+    owner: Address;
+    individual_content: Cell;
+    is_initialized: Bool;
+
+    //********************************************//
+    //                  Messages                  //
+    //********************************************//
+
+    receive(msg: Transfer){
+        let ctx: Context = context();
+        let remain: Int = self._transfer_estimate_rest_value(ctx);
+        self._transfer_validate(ctx, msg, remain);
+        if (self.is_initialized == false) {
+            self.mint(ctx, msg);
+        } else {
+            self.transfer(ctx, msg, remain);
+        }
+    }
+
+    receive(msg: GetStaticData){
+        self._report_static_data(msg);
+    }
+
+    //********************************************//
+    //             Internal functions             //
+    //********************************************//
+
+    // @dev  _transfer_estimate_rest_value calculates the remain amount of nanotons that should be sent back to the old owner
+    inline fun _transfer_estimate_rest_value(ctx: Context): Int {
+        let remain: Int = ctx.value;
+        let tonBalanceBeforeMsg: Int = myBalance() - remain;
+        let storageFee: Int = self.minTonsForStorage - min(tonBalanceBeforeMsg, self.minTonsForStorage);
+        return remain - (storageFee + self.gasConsumption);
+    }
+
+    // @dev  _transfer_validate checks if the request is valid (e.g. the sender is the current owner of the NFT item)
+    //       throws error if the request is invalid
+    // @note one may override this function to implement custom validation logicTransferked
+    virtual inline fun _transfer_validate(ctx: Context, msg: Transfer, remain: Int) {
+        require(ctx.sender == self.owner || ctx.sender == self.collection_address, "NFTItemStandard: Only the owner or collection can transfer the NFT item");
+    }
+
+    // @dev  mint usually performs the minting of the NFT item
+    // @note one may override this function to implement custom minting logic
+    virtual inline fun mint(ctx: Context, msg: Transfer) {
+        require(ctx.sender == self.collection_address, "NFTItemStandard: Only the collection can initialize the NFT item");
+        self.is_initialized = true;
+        self.owner = msg.new_owner;
+        send(SendParameters{
+            to: msg.response_destination,
+            value: 0,
+            mode:  SendIgnoreErrors + SendRemainingValue,
+            body: Excesses { query_id: msg.query_id }.toCell()
+        });
+    }
+
+    // @dev  transfer performs the transfer of the NFT item
+    //      if available, it will send OwnershipAssigned message to the new owner
+    //      then, it will send Excesses message to the response_destination (old owner) if needed.
+    // @note one may override this function to implement custom transfer logic
+    virtual inline fun transfer(ctx: Context, msg: Transfer, remain: Int) {
+        self.owner = msg.new_owner;
+        if (msg.forward_amount > 0) {
+            send(SendParameters{
+                to: msg.new_owner,
+                value: msg.forward_amount,
+                mode: SendIgnoreErrors, 
+                bounce: false,
+                body: OwnershipAssigned{
+                    query_id: msg.query_id,
+                    prev_owner: ctx.sender,
+                    forward_payload: msg.forward_payload
+                }.toCell()
+            }); 
+        }
+        remain = remain - ctx.readForwardFee(); 
+        if (msg.response_destination != newAddress(0, 0) && remain > msg.forward_amount) { 
+            send(SendParameters{ 
+                to: msg.response_destination,
+                value: remain - msg.forward_amount,
+                mode: SendPayGasSeparately,
+                body: Excesses { query_id: msg.query_id }.toCell()
+            });
+        }
+    }
+
+    // @dev  _report_static_data sends a response with the static data of the NFT item
+    virtual inline fun _report_static_data(msg: GetStaticData) {
+        let ctx: Context = context();
+        send(SendParameters {
+            to: ctx.sender,
+            value: 0,
+            mode: SendRemainingValue,
+            bounce: false,
+            body: ReportStaticData{
+                query_id: msg.query_id,
+                index: self.index,
+                collection: self.collection_address
+            }.toCell()
+        });
+    }
+
+    // @dev  _get_nft_data returns the NFT data in the format that complies with TEP-64
+    virtual inline fun _get_nft_data(): NftData {
+        let builder: StringBuilder = beginString();
+        let collectionData: String = self.individual_content.asSlice().asString();
+        builder.append(collectionData);
+        builder.append(self.index.toString());
+        builder.append(".json");
+
+        return NftData {
+            is_initialized: self.is_initialized, 
+            index: self.index, 
+            collection_address: self.collection_address, 
+            owner_address: self.owner,
+            individual_content: builder.toCell()
+        };
+    }
+
+
+    //*********************************//
+    //             Getters             //
+    //*********************************//
+    get fun get_nft_data(): NftData {
+        return self._get_nft_data();
+    }
+}

--- a/contracts/packages/token/nft/extensions/NFTEditable.tact
+++ b/contracts/packages/token/nft/extensions/NFTEditable.tact
@@ -1,0 +1,3 @@
+trait NFTEditable {
+    
+}

--- a/contracts/packages/token/nft/extensions/NFTRoyalty.tact
+++ b/contracts/packages/token/nft/extensions/NFTRoyalty.tact
@@ -1,0 +1,63 @@
+/*
+    This file provides traits for NFT royalty standard is TEP-0066
+    https://github.com/ton-blockchain/TEPs/blob/master/text/0066-nft-royalty-standard.md
+*/
+
+struct RoyaltyParams {
+    numerator: Int as uint16; // numerator to calculate royalty percentage
+    denominator: Int as uint16; // denominator to calculate royalty percentage
+    destination: Address; // Address to receive royalty
+}
+
+message(0x693d3950) GetRoyaltyParams {
+    query_id: Int as uint64; // arbitrary request number for sending ReportRoyaltyParams back with send mode 64
+}
+
+message(0xa8cb00ad) ReportRoyaltyParams {
+    query_id: Int as uint64; // corresponding request number
+    numerator:  Int as uint16; // numerator to calculate royalty percentage, maximum 65535
+    denominator: Int as uint16; // denominator to calculate royalty percentage, maximum 65535
+    destination: Address; // Address to receive royalty
+}
+
+trait NFTRoyaltyStandard {
+    royalty_params: RoyaltyParams;
+    owner_address: Address;
+
+    //********************************************//
+    //                  Messages                  //
+    //********************************************//
+
+    receive(msg: GetRoyaltyParams) {
+        self.report_royalty_params(msg);
+    }
+
+    //********************************************//
+    //             Internal functions             //
+    //********************************************//
+
+    virtual inline fun report_royalty_params(msg: GetRoyaltyParams) {
+        let ctx: Context = context();
+        send(SendParameters{
+            to: ctx.sender,
+            value: 0,
+            mode: SendRemainingValue, 
+            bounce: false,
+            body: ReportRoyaltyParams {
+                query_id: msg.query_id,
+                numerator:  self.royalty_params.numerator,
+                denominator: self.royalty_params.denominator,
+                destination: self.owner_address
+            }.toCell()
+        });
+    }
+
+
+    //*********************************//
+    //             Getters             //
+    //*********************************//
+
+    get fun royalty_params(): RoyaltyParams {
+        return self.royalty_params;
+    }
+}

--- a/contracts/packages/utils/Estimatable.tact
+++ b/contracts/packages/utils/Estimatable.tact
@@ -1,0 +1,11 @@
+trait Estimatable {
+    virtual const gasConsumption: Int = ton("0.05");
+    virtual const minTonsForStorage: Int = ton("0.05");
+
+    virtual fun estimate_rest_value(ctx: Context): Int {
+        let restValue: Int = ctx.value;
+        let tonBalanceBeforeMsg: Int = myBalance() - restValue;
+        let storageFee: Int = self.minTonsForStorage - min(tonBalanceBeforeMsg, self.minTonsForStorage);
+        return restValue - (storageFee + self.gasConsumption);
+    }
+}

--- a/contracts/packages/utils/Lockable.tact
+++ b/contracts/packages/utils/Lockable.tact
@@ -1,0 +1,23 @@
+trait Lockable {
+    is_locked: Bool;
+
+    virtual inline fun lock() {
+        self.is_locked = true;
+    }
+
+    virtual inline fun unlock() {
+        self.is_locked = false;
+    }
+
+    virtual inline fun ensureLocked() {
+        require(self.is_locked, "Lockable: Object is not locked");
+    }
+
+    virtual inline fun ensureUnlocked() {
+        require(!self.is_locked, "Lockable: Object is locked");
+    }
+
+    get fun is_locked(): Bool {
+        return self.is_locked;
+    }
+}

--- a/genWrapper.sh
+++ b/genWrapper.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# List all directories under 'build' and ask the user to choose one
+echo "Available directories under 'build':"
+select DIR_NAME in $(find build -maxdepth 1 -mindepth 1 -type d -exec basename {} \;); do
+    if [[ -n "$DIR_NAME" ]]; then
+        echo "You selected: $DIR_NAME"
+        break
+    else
+        echo "Invalid selection"
+    fi
+done
+
+# Define the path to the source and destination directories
+SRC_DIR="build/$DIR_NAME"
+DEST_DIR="wrappers"
+
+# Ensure that the destination directory exists
+mkdir -p "$DEST_DIR"
+
+# Loop through each `tact_xxx.ts` file in the source directory
+find "$SRC_DIR" -type f -name 'tact_*.ts' | while read -r FILEPATH; do
+    # Extract the filename without the path and extension
+    FILENAME=$(basename -- "$FILEPATH")
+    BASENAME="${FILENAME%.*}"
+    
+    # Define the new file path
+    NEW_FILE="$DEST_DIR/${DIR_NAME}_${BASENAME#tact_}.ts"
+    
+    # Write the export statement to the new file
+    echo "export * from '../$SRC_DIR/${BASENAME}';" > "$NEW_FILE"
+done

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "scripts": {
         "start": "blueprint run",
         "build": "blueprint build",
-        "test": "jest"
+        "test": "jest",
+        "dev": "rm -rf ./build/* && blueprint build --all"
     },
     "devDependencies": {
         "@ton-community/blueprint": "^0.12.0",

--- a/scripts/deployJetton.ts
+++ b/scripts/deployJetton.ts
@@ -1,0 +1,22 @@
+import { toNano } from 'ton-core';
+import { Jetton } from '../wrappers/Jetton';
+import { NetworkProvider } from '@ton-community/blueprint';
+
+export async function run(provider: NetworkProvider) {
+    const jetton = provider.open(await Jetton.fromInit());
+
+    await jetton.send(
+        provider.sender(),
+        {
+            value: toNano('0.05'),
+        },
+        {
+            $$type: 'Deploy',
+            queryId: 0n,
+        }
+    );
+
+    await provider.waitForDeploy(jetton.address);
+
+    // run methods on `jetton`
+}

--- a/tests/Oracle.spec.ts
+++ b/tests/Oracle.spec.ts
@@ -1,10 +1,11 @@
 import { Alarm } from './../build/Oracle/tact_Alarm';
 import { Blockchain, SandboxContract, TreasuryContract, printTransactionFees } from '@ton-community/sandbox';
 import { Address, Cell, address, beginCell, toNano } from 'ton-core';
-import { JettonTransfer, OracleV0, Tock } from '../wrappers/Oracle_OracleV0';
+import { Chime, JettonTransfer, OracleV0, Reset, Tock } from '../wrappers/Oracle_OracleV0';
 import { ExampleJettonMaster } from '../wrappers/Jetton_ExampleJettonMaster';
 import { ExampleJettonWallet } from './../build/Jetton/tact_ExampleJettonWallet';
 import '@ton-community/test-utils';
+import { time } from 'console';
 
 describe('Oracle', () => {
     let blockchain: Blockchain;
@@ -37,7 +38,7 @@ describe('Oracle', () => {
         return initResult ;
     }
 
-    async function mintTokensToWatchmaker(jettonMaster: SandboxContract<ExampleJettonMaster>, watchmaker: SandboxContract<TreasuryContract>) {
+    async function mintToken(jettonMaster: SandboxContract<ExampleJettonMaster>, watchmaker: SandboxContract<TreasuryContract>) {
         return await jettonMaster.send(
             watchmaker.getSender(),
             { value: toNano('1') },
@@ -73,6 +74,33 @@ describe('Oracle', () => {
         return await watchmakerJettonContract.send(
             watchmaker.getSender(),
             { value: toNano(transferValue) },
+            jettonTransfer
+        );
+    }
+
+    async function windInJettonTransfer(timekeeper: SandboxContract<TreasuryContract>, oracle: SandboxContract<OracleV0>,alarmIndex: number,buyNum:number,side: number, transferValue: number) {
+        let op = 1; // 1 means wind
+        const forwardInfo: Cell = beginCell().storeUint(op,8).storeUint(alarmIndex,256).storeUint(buyNum,32).storeUint(side,1).endCell();
+        const jettonTransfer: JettonTransfer = {
+            $$type: 'JettonTransfer',
+            query_id: 0n,
+            amount: 1000000n,
+            destination: oracle.address,
+            response_destination: timekeeper.address,
+            custom_payload: null,
+            forward_ton_amount: toNano("5"),
+            forward_payload: beginCell().storeRef(forwardInfo).endCell(),
+        };
+
+        // watchmaker's jetton wallet address
+        const timekeeperWalletAddress = await jettonMaster.getGetWalletAddress(timekeeper.address);
+        // watchmaker's jetton wallet
+        const timekeeperJettonContract = blockchain.openContract(await ExampleJettonWallet.fromAddress(timekeeperWalletAddress));
+        return await timekeeperJettonContract.send(
+            timekeeper.getSender(),
+            {
+                value: toNano(transferValue),
+            },
             jettonTransfer
         );
     }
@@ -256,7 +284,7 @@ describe('Oracle', () => {
         // Initialize oracle
         const initResult = await initializeOracle(oracle, owner);
         // Mint tokens to watchmaker
-        const mintyResult = await mintTokensToWatchmaker(jettonMaster, watchmaker);
+        const mintyResult = await mintToken(jettonMaster, watchmaker);
         // watchmaker post price to oracle
         const baseAssetPriceAmount = 3; // 1 ton = 3usdt
         const baseAssetAmount = 10; // 10usdt
@@ -273,7 +301,7 @@ describe('Oracle', () => {
         // Initialize oracle
         const initResult = await initializeOracle(oracle, owner);
         // Mint tokens to watchmaker
-        const mintyResult = await mintTokensToWatchmaker(jettonMaster, watchmaker);
+        const mintyResult = await mintToken(jettonMaster, watchmaker);
         // watchmaker post price to oracle
         const baseAssetPriceAmount = 3; // 1 ton = 3usdt
         const baseAssetAmount = 10; // 10usdt
@@ -313,7 +341,7 @@ describe('Oracle', () => {
         // Initialize oracle
         const initResult = await initializeOracle(oracle, owner);
         // Mint tokens to watchmaker
-        const mintyResult = await mintTokensToWatchmaker(jettonMaster, watchmaker);
+        const mintyResult = await mintToken(jettonMaster, watchmaker);
         // watchmaker post price to oracle
         const baseAssetPriceAmount = 3; // 1 ton = 3usdt
         const baseAssetAmount = 10; // 10usdt
@@ -329,7 +357,7 @@ describe('Oracle', () => {
         // Initialize oracle
         const initResult = await initializeOracle(oracle, owner);
         // Mint tokens to watchmaker
-        const mintyResult = await mintTokensToWatchmaker(jettonMaster, watchmaker);
+        const mintyResult = await mintToken(jettonMaster, watchmaker);
         // watchmaker post price to oracle
         const baseAssetPriceAmount = 3; // 1 ton = 3usdt
         const baseAssetAmount = 10; // 10usdt
@@ -342,11 +370,13 @@ describe('Oracle', () => {
         expect(alarmIndexAfter).toEqual(1n);
         // Timekeeper send wind msg to oracle
         let timekeeper: SandboxContract<TreasuryContract> = await blockchain.treasury('timekeeper');
-        const mintTimekeeperResult = await mintTokensToWatchmaker(jettonMaster, timekeeper);
+        const mintTimekeeperResult = await mintToken(jettonMaster, timekeeper);
         let alarmIndex = 0;
         let buyNum = 1;
         let side = 0;
-        const forwardInfo: Cell = beginCell().storeUint(1,8).storeUint(alarmIndex,256).storeUint(buyNum,32).storeUint(side,32).endCell();
+        //const windResult = await windInJettonTransfer(timekeeper, oracle, alarmIndex, buyNum, side, transferValue);
+        let op = 1; // 1 means wind
+        const forwardInfo: Cell = beginCell().storeUint(op,8).storeUint(alarmIndex,256).storeUint(buyNum,32).storeUint(side,32).endCell();
         const jettonTransfer: JettonTransfer = {
             $$type: 'JettonTransfer',
             query_id: 0n,
@@ -369,7 +399,7 @@ describe('Oracle', () => {
             },
             jettonTransfer
         );
-        printTransactionFees(windResult.transactions);
+        //printTransactionFees(windResult.transactions);
 
         // Check that timekeeper send JettonTransfer msg to her jetton wallet
         expect(windResult.transactions).toHaveTransaction({
@@ -386,26 +416,30 @@ describe('Oracle', () => {
             success: true,
         });
 
+        // Check that oracle's jetton wallet send JettonTransferNotification msg to oracle
         expect(windResult.transactions).toHaveTransaction({
             from: oracleWalletAddress,
             to: oracle.address,
             success: true,
         });
 
+        // Check that oracle send Reset msg to Alarm0
         let AlarmAddress = await oracle.getGetAlarmAddress(0n);
-        // Check that oracle build alarm successfully
+        let alarm0 = blockchain.openContract(await Alarm.fromAddress(AlarmAddress));
         expect(windResult.transactions).toHaveTransaction({
             from: oracle.address,
             to: AlarmAddress,
             success: true,
         });
 
+        // Check that Alarm contract send Chime msg to oracle
         expect(windResult.transactions).toHaveTransaction({
             from: AlarmAddress,
             to: oracle.address,
             success: true,
         });
-
+        
+        // Check that oracle build a new Alarm1 successfully
         let Alarm1Address = await oracle.getGetAlarmAddress(1n);
         expect(windResult.transactions).toHaveTransaction({
             from: oracle.address,
@@ -413,11 +447,207 @@ describe('Oracle', () => {
             success: true,
         });
 
+        // Return the remaining funds back to the Timekeeper
         expect(windResult.transactions).toHaveTransaction({
             from: Alarm1Address,
             to: timekeeper.address,
             success: true,
         });
 
+
+        // Check that baseAssetScale is 0
+        let baseAssetScale = await alarm0.getGetBaseAssetScale();
+        expect(baseAssetScale).toEqual(0n);
+
+        // Check that quoteAssetScale is 2
+        let quoteAssetScale = await alarm0.getGetQuoteAssetScale();
+        expect(quoteAssetScale).toEqual(2n);
+
+        // Check that remainScale is 0
+        let remainScale = await alarm0.getGetRemainScale();
+        expect(remainScale).toEqual(0n);
+
+        // Check that alarm count is 2 (Timekeeper will build a new alarm) 
+        alarmIndexAfter = await oracle.getTotalAmount();
+        expect(alarmIndexAfter).toEqual(2n);
+
+        let AlarmAddress2 = await oracle.getGetAlarmAddress(1n);
+        let alarm02 = blockchain.openContract(await Alarm.fromAddress(AlarmAddress2));
+        // Check that baseAssetScale is 0
+        let baseAssetScale2 = await alarm02.getGetBaseAssetScale();
+        expect(baseAssetScale2).toEqual(2n);
+
+        // Check that quoteAssetScale is 2
+        let quoteAssetScale2 = await alarm02.getGetQuoteAssetScale();
+        expect(quoteAssetScale2).toEqual(2n);
+
+        // Check that remainScale is 0
+        let remainScale2 = await alarm02.getGetRemainScale();
+        expect(remainScale2).toEqual(2n);
+
+    });
+
+    it('Should return funds if side or alarmIndex is incorrect', async () => {
+            // Initialize oracle
+            const initResult = await initializeOracle(oracle, owner);
+            // Mint tokens to watchmaker
+            const mintyResult = await mintToken(jettonMaster, watchmaker);
+            // watchmaker post price to oracle
+            const baseAssetPriceAmount = 3; // 1 ton = 3usdt
+            const baseAssetAmount = 10; // 10usdt
+            const expireAt = 1000;
+            const transferValue = 10;
+            const scale = 1;
+            const transfterResult = await tickInJettonTransfer(watchmaker, oracle, baseAssetPriceAmount, baseAssetAmount, expireAt,scale, transferValue);
+            // Check that alarm count is 1
+            let alarmIndexAfter = await oracle.getTotalAmount();
+            expect(alarmIndexAfter).toEqual(1n);
+            // Timekeeper send wind msg to oracle
+            let timekeeper: SandboxContract<TreasuryContract> = await blockchain.treasury('timekeeper');
+
+            // timekeeper's jetton wallet address
+            const oracleWalletAddress = await jettonMaster.getGetWalletAddress(oracle.address);
+            const timekeeperWalletAddress = await jettonMaster.getGetWalletAddress(timekeeper.address);
+            // timekeeper's jetton wallet
+            const oracleJettonContract = blockchain.openContract(await ExampleJettonWallet.fromAddress(oracleWalletAddress));
+            const mintTimekeeperResult = await mintToken(jettonMaster, timekeeper);
+            let wrongAlarmIndex = 10;
+            let buyNum = 1;
+            let side = 0;
+            let windResult = await windInJettonTransfer(timekeeper, oracle, wrongAlarmIndex, buyNum, side, transferValue);
+
+            // Fail because alarmIndex is incorrect
+            expect(windResult.transactions).toHaveTransaction({
+                from: oracleWalletAddress,
+                to: oracle.address,
+                success: false,
+            });
+
+            // It's no way to assign side to a wrong value, so we don't test it here
+            // Becuase its size is 1 bit, so it's no way to assign a wrong value(others value than 0 and 1) to it
+    });
+
+    it('Should fail transaction if Reset message is not from Oracle', async () => {
+        // Initialize oracle
+        const initResult = await initializeOracle(oracle, owner);
+        // Mint tokens to watchmaker
+        const mintyResult = await mintToken(jettonMaster, watchmaker);
+        // watchmaker post price to oracle
+        const baseAssetPriceAmount = 3; // 1 ton = 3usdt
+        const baseAssetAmount = 10; // 10usdt
+        const expireAt = 1000;
+        const transferValue = 10;
+        const scale = 1;
+        const transfterResult = await tickInJettonTransfer(watchmaker, oracle, baseAssetPriceAmount, baseAssetAmount, expireAt,scale, transferValue);
+
+        const resetMsg: Reset = {
+            $$type: 'Reset',
+            sender: owner.address,
+            buyNum: 1n, // The number of scales to buy
+            side: 1n, // 0 for baseAsset, 1 for quoteAsset
+            quoteAssetAmount: 1n // The amount of quoteAsset oracle received
+        };
+        let AlarmAddress = await oracle.getGetAlarmAddress(0n);
+        const alarm0 = blockchain.openContract(await Alarm.fromAddress(AlarmAddress));
+        const tockResult = await alarm0.send(
+            watchmaker.getSender(),
+            {
+                value: toNano('10'),
+            },
+            resetMsg
+        );
+        // should fail because msg is not from oracle
+        expect(tockResult.transactions).toHaveTransaction({
+            from: watchmaker.address,
+            to: AlarmAddress,
+            success: false,
+        });
+    });
+
+    it('Should fail transaction if Chime message not came from Alarm contract', async () => {
+        // Initialize oracle
+        const initResult = await initializeOracle(oracle, owner);
+        // Mint tokens to watchmaker
+        const mintyResult = await mintToken(jettonMaster, watchmaker);
+        // watchmaker post price to oracle
+        const baseAssetPriceAmount = 3; // 1 ton = 3usdt
+        const baseAssetAmount = 10; // 10usdt
+        const expireAt = 1000;
+        const transferValue = 10;
+        const scale = 1;
+        const transfterResult = await tickInJettonTransfer(watchmaker, oracle, baseAssetPriceAmount, baseAssetAmount, expireAt,scale, transferValue);
+
+        const resetMsg: Chime = {
+            $$type: 'Chime',
+            alarmIndex: 0n,
+            timeKeeper: owner.address,
+            createdAt: 110n,
+            baseAssetPrice: 1n,
+            remainScale: 1n,
+            newScale: 1n,
+            refundBaseAssetAmount: 1n,
+            refundQuoteAssetAmount: 1n
+        };
+        let AlarmAddress = await oracle.getGetAlarmAddress(0n);
+        const alarm0 = blockchain.openContract(await Alarm.fromAddress(AlarmAddress));
+        const tockResult = await oracle.send(
+            owner.getSender(),
+            {
+                value: toNano('10'),
+            },
+            resetMsg
+        );
+        // should fail because msg is not from alarm
+        expect(tockResult.transactions).toHaveTransaction({
+            from: owner.address,
+            to: oracle.address,
+            success: false,
+        });
+    });
+
+    it('Should update price according to the formula in the Chime msg', async () => {
+        // Initialize oracle
+        const initResult = await initializeOracle(oracle, owner);
+        // Mint tokens to watchmaker
+        const mintyResult = await mintToken(jettonMaster, watchmaker);
+        // watchmaker post price to oracle
+        const baseAssetPriceAmount = 3; // 1 ton = 3usdt
+        const baseAssetAmount = 10; // 10usdt
+        const expireAt = 1000;
+        const transferValue = 10;
+        const scale = 1;
+        const transfterResult = await tickInJettonTransfer(watchmaker, oracle, baseAssetPriceAmount, baseAssetAmount, expireAt,scale, transferValue);
+        // Check that alarm count is 1
+        let alarmIndexAfter = await oracle.getTotalAmount();
+        expect(alarmIndexAfter).toEqual(1n);
+        // Timekeeper send wind msg to oracle
+        let timekeeper: SandboxContract<TreasuryContract> = await blockchain.treasury('timekeeper');
+
+        // timekeeper's jetton wallet address
+        const oracleWalletAddress = await jettonMaster.getGetWalletAddress(oracle.address);
+        const timekeeperWalletAddress = await jettonMaster.getGetWalletAddress(timekeeper.address);
+        // timekeeper's jetton wallet
+        const oracleJettonContract = blockchain.openContract(await ExampleJettonWallet.fromAddress(oracleWalletAddress));
+        const mintTimekeeperResult = await mintToken(jettonMaster, timekeeper);
+        let alarmIndex = 0;
+        let buyNum = 1;
+        let side = 0;
+        let windResult = await windInJettonTransfer(timekeeper, oracle, alarmIndex, buyNum, side, transferValue);
+        // Check that alarm count is 2 (Timekeeper will build a new alarm) 
+        alarmIndexAfter = await oracle.getTotalAmount();
+        expect(alarmIndexAfter).toEqual(2n);
+        let AlarmAddress = await oracle.getGetAlarmAddress(1n);
+        let alarmContract = blockchain.openContract(await Alarm.fromAddress(AlarmAddress));
+
+        // Timekeeper2 send wind msg to take money from timekeeper1
+        let timekeeper2: SandboxContract<TreasuryContract> = await blockchain.treasury('timekeeper2');
+        await mintToken(jettonMaster, timekeeper2);
+        let alarmIndex2 = 1;
+        let buyNum2 = 1;
+        let side2 = 0;
+        let latestPrice = await oracle.getGetLatestBaseAssetPrice();
+        let windResult2 = await windInJettonTransfer(timekeeper, oracle, alarmIndex2, buyNum2, side2, transferValue);
+        latestPrice = await oracle.getGetLatestBaseAssetPrice();
+        // Not Finished, cause for now the alarm contract that timekeeper2 build doesn't have baseprice
     });
 });

--- a/tests/Oracle.spec.ts
+++ b/tests/Oracle.spec.ts
@@ -1,23 +1,97 @@
-import { Blockchain, SandboxContract } from '@ton-community/sandbox';
-import { toNano } from 'ton-core';
-import { Oracle } from '../wrappers/Oracle';
+import { Alarm } from './../build/Oracle/tact_Alarm';
+import { Blockchain, SandboxContract, TreasuryContract, printTransactionFees } from '@ton-community/sandbox';
+import { Address, Cell, address, beginCell, toNano } from 'ton-core';
+import { JettonTransfer, OracleV0 } from '../wrappers/Oracle_OracleV0';
+import { ExampleJettonMaster } from '../wrappers/Jetton_ExampleJettonMaster';
+import { ExampleJettonWallet } from './../build/Jetton/tact_ExampleJettonWallet';
 import '@ton-community/test-utils';
 
 describe('Oracle', () => {
     let blockchain: Blockchain;
-    let oracle: SandboxContract<Oracle>;
+    let oracle: SandboxContract<OracleV0>;
+    let owner: SandboxContract<TreasuryContract>;
+    let watchmaker: SandboxContract<TreasuryContract>;
+    let jettonMaster: SandboxContract<ExampleJettonMaster>;
+    let zero_address: Address = new Address(0, Buffer.alloc(32));
+    const DECIMAL = 6n
+
+    function toTic(input: number): bigint {
+        const basePrice = input * 10 ** Number(DECIMAL);
+        return BigInt(basePrice * 2 ** 68);
+    }
+
+    async function initializeOracle(oracle: SandboxContract<OracleV0>, owner: SandboxContract<TreasuryContract>){
+        const oracleWalletAddress = await jettonMaster.getGetWalletAddress(oracle.address);
+        const oracleJettonContract = blockchain.openContract(await ExampleJettonWallet.fromAddress(oracleWalletAddress));
+    
+        const initResult = await oracle.send(
+            owner.getSender(),
+            { value: toNano('0.05') },
+            {
+                $$type: 'Initialize',
+                baseAssetWallet: zero_address,
+                quoteAssetWallet: oracleWalletAddress
+            }
+        );
+    
+        return initResult ;
+    }
+
+    async function mintTokensToWatchmaker(jettonMaster: SandboxContract<ExampleJettonMaster>, watchmaker: SandboxContract<TreasuryContract>) {
+        return await jettonMaster.send(
+            watchmaker.getSender(),
+            { value: toNano('1') },
+            'Mint:1'
+        );
+    }
+    
+    async function prepareAndSendJettonTransfer(watchmaker: SandboxContract<TreasuryContract>, oracle: SandboxContract<OracleV0>, baseAssetPriceAmount: number, baseAssetAmount: number, expireAt: number, transferValue: number) {
+        const baseAssetPrice = toTic(baseAssetPriceAmount);
+        const forwardTonAmount = toNano(toTic(baseAssetAmount) / baseAssetPrice) + toNano(0.5);
+    
+        const forwardInfo: Cell = beginCell()
+            .storeUint(0, 8)
+            .storeUint(expireAt, 256)
+            .storeUint(baseAssetPrice, 256)
+            .storeUint(1, 32)
+            .endCell();
+    
+        const jettonTransfer: JettonTransfer = {
+            $$type: 'JettonTransfer',
+            query_id: 0n,
+            amount: BigInt(baseAssetAmount) * 10n ** DECIMAL,
+            destination: oracle.address,
+            response_destination: watchmaker.address,
+            custom_payload: null,
+            forward_ton_amount: forwardTonAmount,
+            forward_payload: beginCell().storeRef(forwardInfo).endCell(),
+        };
+    
+        const watchmakerWalletAddress = await jettonMaster.getGetWalletAddress(watchmaker.address);
+        const watchmakerJettonContract = blockchain.openContract(await ExampleJettonWallet.fromAddress(watchmakerWalletAddress));
+    
+        return await watchmakerJettonContract.send(
+            watchmaker.getSender(),
+            { value: toNano(transferValue) },
+            jettonTransfer
+        );
+    }
+    
+    
 
     beforeEach(async () => {
         blockchain = await Blockchain.create();
+        owner = await blockchain.treasury('owner');
+        watchmaker = await blockchain.treasury('watchmaker');
+        const jetton_content: Cell = beginCell().endCell();
+        jettonMaster = blockchain.openContract(await ExampleJettonMaster.fromInit(owner.address, jetton_content));
 
-        oracle = blockchain.openContract(await Oracle.fromInit());
-
-        const deployer = await blockchain.treasury('deployer');
+        oracle = blockchain.openContract(await OracleV0.fromInit(zero_address, jettonMaster.address))
 
         const deployResult = await oracle.send(
-            deployer.getSender(),
+            owner.getSender(),
             {
-                value: toNano('0.05'),
+                value: toNano('5'),
             },
             {
                 $$type: 'Deploy',
@@ -26,15 +100,164 @@ describe('Oracle', () => {
         );
 
         expect(deployResult.transactions).toHaveTransaction({
-            from: deployer.address,
+            from: owner.address,
             to: oracle.address,
             deploy: true,
             success: true,
         });
+
+        const masterDeployResult = await jettonMaster.send(
+            owner.getSender(),
+            {
+                value: toNano('0.05'),
+            },
+            {
+                $$type: 'Deploy',
+                queryId: 0n,
+            }
+        );
     });
 
     it('should deploy', async () => {
         // the check is done inside beforeEach
         // blockchain and oracle are ready to use
+    });
+
+    it('should watchmaker sends tick msg to oralce', async () => {
+        // Initialize oracle
+        // oracle's jetton wallet address
+        const oracleWalletAddress = await jettonMaster.getGetWalletAddress(oracle.address);
+        // oracle's jetton wallet
+        const oracleJettonContract = blockchain.openContract(await ExampleJettonWallet.fromAddress(oracleWalletAddress));
+        const initResult = await oracle.send(
+            owner.getSender(),
+            {
+                value: toNano('0.05'),
+            },
+            {
+                $$type: 'Initialize',
+                baseAssetWallet: zero_address,
+                quoteAssetWallet: oracleWalletAddress
+            }
+        );
+
+        // Check that Init was successful
+        expect(initResult.transactions).toHaveTransaction({
+            from: owner.address,
+            to: oracle.address,
+            success: true,
+        });
+
+        // Mint tokens to watchmaker
+        const mintyResult = await jettonMaster.send(
+            watchmaker.getSender(),
+            {
+                value: toNano('1'),
+            },
+            'Mint:1'
+        );
+        // watchmaker's jetton wallet address
+        const watchmakerWalletAddress = await jettonMaster.getGetWalletAddress(watchmaker.address);
+        // watchmaker's jetton wallet
+        const watchmakerJettonContract = blockchain.openContract(await ExampleJettonWallet.fromAddress(watchmakerWalletAddress));
+
+
+        // watchmaker transfer 1 ton and 10 usdt to oracle
+        let baseAssetPriceAmount = 3;
+        let baseAssetPrice = toTic(baseAssetPriceAmount);//Number(2.5 * 1000000) << 68;
+        let baseAssetAmount = 10n * 1000000n;
+        let forward_ton_amount = toNano(toTic(10)/baseAssetPrice) + toNano(0.5);
+        let expireAt = 1000;
+        let forwardInfo: Cell = beginCell().storeUint(0,8).storeUint(expireAt,256).storeUint(baseAssetPrice,256).storeUint(1,32).endCell();
+        const jettonTransfer: JettonTransfer = {
+            $$type: 'JettonTransfer',
+            query_id: 0n,
+            amount: baseAssetAmount,
+            destination: oracle.address,
+            response_destination: watchmaker.address,
+            custom_payload: null,
+            forward_ton_amount: forward_ton_amount,
+            forward_payload: beginCell().storeRef(forwardInfo).endCell(),
+        };
+        const transfterResult = await watchmakerJettonContract.send(
+            watchmaker.getSender(),
+            {
+                value: toNano('10'),
+            },
+            jettonTransfer
+        );
+
+        // Check that watchmaker send JettonTransfer msg to her jetton wallet
+        expect(transfterResult.transactions).toHaveTransaction({
+            from: watchmaker.address,
+            to: watchmakerWalletAddress,
+            success: true,
+        });
+
+        // Check that watchmaker's jetton wallet send JettonInternalTransfer msg to Bob's jetton wallet
+        expect(transfterResult.transactions).toHaveTransaction({
+            from: watchmakerWalletAddress,
+            to: oracleWalletAddress,
+            success: true,
+        });
+
+        // Check that oracle's jetton wallet send JettonTransferNotification msg to oracle
+        expect(transfterResult.transactions).toHaveTransaction({
+            from: oracleWalletAddress,
+            to: oracle.address,
+            success: true,
+        });
+        
+        // Check that oracle build alarm successfully
+        let AlarmAddress = await oracle.getGetAlarmAddress(0n);
+        expect(transfterResult.transactions).toHaveTransaction({
+            from: oracle.address,
+            to: AlarmAddress,
+            success: true,
+        });
+
+        // Check that alarm send build alarm msg to watchmaker
+        expect(transfterResult.transactions).toHaveTransaction({
+            from: AlarmAddress,
+            to: watchmaker.address,
+            success: true,
+        });
+
+        const alarm0 = blockchain.openContract(await Alarm.fromAddress(AlarmAddress));
+        // Check that watchmaker is watchmaker
+        let watchmakerAddress = await alarm0.getGetWatchmaker();
+        expect(watchmakerAddress.toString()).toEqual(watchmaker.address.toString());
+
+        // Check that baseAssetScale is 1
+        let baseAssetScale = await alarm0.getGetBaseAssetScale();
+        expect(baseAssetScale).toEqual(1n);
+
+        // Check that quoteAssetScale is 1
+        let quoteAssetScale = await alarm0.getGetQuoteAssetScale();
+        expect(quoteAssetScale).toEqual(1n);
+
+        // Check that remainScale is 1
+        let remainScale = await alarm0.getGetRemainScale();
+        expect(remainScale).toEqual(1n);
+
+        // Check that baseAssetPrice is 3
+        let price = await alarm0.getGetBaseAssetPrice();
+        expect(price).toEqual(baseAssetPrice);
+
+        //printTransactionFees(transfterResult.transactions);
+
+    });
+
+    it('should watchmaker sends tick msg to oralce by functions', async () => {
+        // Initialize oracle
+        const initResult = await initializeOracle(oracle, owner);
+        // Mint tokens to watchmaker
+        const mintyResult = await mintTokensToWatchmaker(jettonMaster, watchmaker);
+        // watchmaker post price to oracle
+        const baseAssetPriceAmount = 3; // 1 ton = 3usdt
+        const baseAssetAmount = 10; // 10usdt
+        const expireAt = 1000;
+        const transferValue = 10;
+        const transfterResult = await prepareAndSendJettonTransfer(watchmaker, oracle, baseAssetPriceAmount, baseAssetAmount, expireAt, transferValue);
     });
 });

--- a/wrappers/Jetton.compile.ts
+++ b/wrappers/Jetton.compile.ts
@@ -1,0 +1,6 @@
+import { CompilerConfig } from '@ton-community/blueprint';
+
+export const compile: CompilerConfig = {
+    lang: 'tact',
+    target: 'contracts/jetton.tact',
+};

--- a/wrappers/Jetton.ts
+++ b/wrappers/Jetton.ts
@@ -1,0 +1,1 @@
+export * from '../build/Jetton/tact_Jetton';

--- a/wrappers/Jetton_ExampleJettonMaster.ts
+++ b/wrappers/Jetton_ExampleJettonMaster.ts
@@ -1,0 +1,1 @@
+export * from '../build/Jetton/tact_ExampleJettonMaster';

--- a/wrappers/Jetton_ExampleJettonWallet.ts
+++ b/wrappers/Jetton_ExampleJettonWallet.ts
@@ -1,0 +1,1 @@
+export * from '../build/Jetton/tact_ExampleJettonWallet';

--- a/wrappers/Jetton_Jetton.ts
+++ b/wrappers/Jetton_Jetton.ts
@@ -1,0 +1,1 @@
+export * from '../build/Jetton/tact_Jetton';

--- a/wrappers/Oracle.compile.ts
+++ b/wrappers/Oracle.compile.ts
@@ -3,4 +3,11 @@ import { CompilerConfig } from '@ton-community/blueprint';
 export const compile: CompilerConfig = {
     lang: 'tact',
     target: 'contracts/oracle.tact',
+    options: {
+        debug: true,
+        external: true,
+        experimental: {
+            inline: true,
+        },
+    },
 };

--- a/wrappers/Oracle_Alarm.ts
+++ b/wrappers/Oracle_Alarm.ts
@@ -1,0 +1,1 @@
+export * from '../build/Oracle/tact_Alarm';

--- a/wrappers/Oracle_OracleV0.ts
+++ b/wrappers/Oracle_OracleV0.ts
@@ -1,0 +1,1 @@
+export * from '../build/Oracle/tact_OracleV0';


### PR DESCRIPTION
Code I changed:
1. In the `receive(msg: JettonTransferNotification)`, I added a `sendBackAmount` variable to record how much money needs to be returned to the user after building alarm successfully. Also, I changed the mode to `SendIgnoreErrors` and set the `value` to `sendBackAmount` in the `receive(msg: JettonTransferNotification)`.
2. In the `receive(msg: JettonTransferNotification)`, `needBaseAssetAmount = msg.amount.float() / baseAssetPrice;` After calculation, it needs to be multiplied by `10**9` to represent the amount of ton to be transferred (e.g., 10/2.5 = 4, which means 4 tons, therefore 4 should be multiplied by Decimal)
3. In the Alarm contract, I modified `requireNotInitialized` to `self.watchmaker == newAddress(0, 0)`. This means that if `watchmaker.address == 0x00`, it indicates that the alarm has not been initialized yet (originally it was judged by `self.oracleAddress == newAddress(0, 0)`).
4. In the `receive(msg: Reset)` function, I changed the `require(self.remainScale > msg.buyNum, "Not enough scale to buy");` to `>=`, to allow the Timekeeper to buy all of the `remainScale`.
5. In the `receive(msg: JettonTransferNotification)` function, within `if(opCode == 1)`, the `Reset` message's sender is `msg.sender` (timekeeper), not `ctx.sender` (oracle jetton wallet).
6. In the `receive(msg: Chime)` function, when deploying a new alarm, a basic `value` is required to build the contract. I have currently hardcoded it as 0.05 ton.
7. In the `receive(msg: Chime)` function, after building the alarm, `totalAlarms` is not incremented by 1.

Code need to be revised:
1. In the `receive(msg: JettonTransferNotification)` function of the Oracle contract, code for returning Jettons to the user was not written.
2. When the timekeeper sends the wind message, it does not specify the new price to be offered, therefore there is no check to see if the jettons and tons sent are sufficient for this quotation.
3. In the `receive(msg: Reset)` function, `baseAssetPrice` is not overwritten with a new value. It should be changed to the new price as perceived by the timekeeper. Currently, it is 0, so the `baseAssetPrice` for the new alarm built by the timekeeper is also 0.
4. In the `receive(msg: Chime)` function, in addition to checking if `msg.remainScale > 0`, should there also be a check to see if the verification stage has passed? Only if it has passed, the price can be changed.
5. In `receive(msg: Reset)`, if `require(self.remainScale >= msg.buyNum, "Not enough scale to buy")` is not met, the jettons are not returned to the timekeeper.